### PR TITLE
Register a NameService for better TLS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,3 +113,14 @@ To record the logs from your containers specify a location:
   }
 
 This will automatically record logs for all containers in real time to the specified directory. Collection will stop when the containers terminate.
+
+Accessing services in a container with TLS
+------------------------------------------
+
+When your containerised service is configured to use TLS, it's difficult to communicate with it, because cert validation will generally fail. There is an optional feature that replaces the internal Java `NameService` with a cert. To use it, set the system property `sun.net.spi.nameservice.provider.1` to `dns,docker-compose-rule`. When set, one can communicate with container `foo` at hostname `foo`.
+
+An example of this (with Gradle) is:
+
+    test {
+        systemProperty "sun.net.spi.nameservice.provider.1", "dns,docker-compose-rule"
+    } 

--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,10 @@ configurations.all {
     )
 }
 
+test {
+    systemProperty "sun.net.spi.nameservice.provider.1", "dns,docker-compose-rule"
+}
+
 dependencies {
     compile "org.slf4j:slf4j-api:$slf4jVersion"
     compile "org.apache.commons:commons-lang3:3.0"

--- a/src/main/java/com/palantir/docker/compose/resolve/DockerNameService.java
+++ b/src/main/java/com/palantir/docker/compose/resolve/DockerNameService.java
@@ -1,0 +1,76 @@
+package com.palantir.docker.compose.resolve;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+import com.google.common.net.InetAddresses;
+import com.palantir.docker.compose.Container;
+import com.palantir.docker.compose.DockerMachine;
+
+import sun.net.spi.nameservice.NameService;
+
+public class DockerNameService implements NameService {
+    private final NameService delegate;
+
+    private static final Map<String, String> containers = new ConcurrentHashMap<>();
+
+    public DockerNameService(NameService delegate) {
+        this.delegate = Preconditions.checkNotNull(delegate, "delegate");
+    }
+
+    @VisibleForTesting
+    static void unregisterAll() {
+        containers.clear();
+    }
+
+    public static void register(DockerMachine dockerMachine, Collection<Container> toRegister) {
+        Set<String> containerNames = toRegister
+                .stream()
+                .map(Container::getContainerName)
+                .collect(Collectors.toSet());
+
+        Preconditions.checkArgument(Sets.intersection(containerNames, containers.keySet()).isEmpty(),
+                "Cannot run two containers with the same name simultaneously.");
+
+        Map<String, String> containerNamesToHostname = Maps.toMap(containerNames, container -> dockerMachine.getIp());
+
+        containers.putAll(containerNamesToHostname);
+    }
+
+    public static void unregister(Collection<Container> toRemove) {
+        toRemove.forEach(c -> containers.remove(c.getContainerName()));
+    }
+
+    @Override
+    public InetAddress[] lookupAllHostAddr(String hostName) throws UnknownHostException {
+        boolean hostIsContainerName = containers.containsKey(hostName);
+
+        if (!hostIsContainerName) {
+            return delegate.lookupAllHostAddr(hostName);
+        }
+
+        String dockerMachineAddress = containers.get(hostName);
+
+        boolean hostIsIpAddress = InetAddresses.isInetAddress(dockerMachineAddress);
+
+        if (hostIsIpAddress) {
+            return new InetAddress[] { InetAddresses.forString(dockerMachineAddress) };
+        } else {
+            return delegate.lookupAllHostAddr(dockerMachineAddress);
+        }
+    }
+
+    @Override
+    public String getHostByAddr(byte[] bytes) throws UnknownHostException {
+        return delegate.getHostByAddr(bytes);
+    }
+}

--- a/src/main/java/com/palantir/docker/compose/resolve/DockerNameServiceDescriptor.java
+++ b/src/main/java/com/palantir/docker/compose/resolve/DockerNameServiceDescriptor.java
@@ -1,0 +1,23 @@
+package com.palantir.docker.compose.resolve;
+
+import sun.net.spi.nameservice.NameService;
+import sun.net.spi.nameservice.NameServiceDescriptor;
+import sun.net.spi.nameservice.dns.DNSNameService;
+
+public class DockerNameServiceDescriptor implements NameServiceDescriptor {
+
+    @Override
+    public NameService createNameService() throws Exception {
+        return new DockerNameService(new DNSNameService());
+    }
+
+    @Override
+    public String getProviderName() {
+        return "docker-compose-rule";
+    }
+
+    @Override
+    public String getType() {
+        return "dns";
+    }
+}

--- a/src/main/resources/META-INF/services/sun.net.spi.nameservice.NameServiceDescriptor
+++ b/src/main/resources/META-INF/services/sun.net.spi.nameservice.NameServiceDescriptor
@@ -1,0 +1,1 @@
+com.palantir.docker.compose.resolve.DockerNameServiceDescriptor

--- a/src/test/java/com/palantir/docker/compose/DockerCompositionIntegrationTest.java
+++ b/src/test/java/com/palantir/docker/compose/DockerCompositionIntegrationTest.java
@@ -9,6 +9,7 @@ import static com.palantir.docker.compose.IOMatchers.fileWithName;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.InetAddress;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -41,6 +42,18 @@ public class DockerCompositionIntegrationTest {
     @Test
     public void canAccessExternalPortForInternalPortOfMachine() {
         assertThat(composition.portOnContainerWithInternalMapping("db", 5432).isListeningNow(), is(true));
+    }
+
+    @Test
+    public void dockerMachineNamesAreCorrectlyRedirected() throws IOException, InterruptedException {
+        assertThat(InetAddress.getByName("db").getHostAddress(),
+                is(composition.portOnContainerWithExternalMapping("db", 5433).getIp()));
+    }
+
+    @Test
+    public void nonDockerMachineNamesAreNotRedirected() throws IOException, InterruptedException {
+        assertThat(InetAddress.getByName("localhost").getHostAddress(),
+                is("127.0.0.1"));
     }
 
     @SuppressWarnings("unchecked")

--- a/src/test/java/com/palantir/docker/compose/DockerCompositionTest.java
+++ b/src/test/java/com/palantir/docker/compose/DockerCompositionTest.java
@@ -23,6 +23,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.commons.io.IOUtils;
 import org.joda.time.Duration;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -55,6 +56,11 @@ public class DockerCompositionTest {
         dockerComposition.after();
         verify(dockerComposeExecutable).kill();
         verify(dockerComposeExecutable).rm();
+    }
+
+    @Before
+    public void before() {
+        when(dockerMachine.getIp()).thenReturn("fake ip");
     }
 
     @Test

--- a/src/test/java/com/palantir/docker/compose/resolve/DockerNameServiceTest.java
+++ b/src/test/java/com/palantir/docker/compose/resolve/DockerNameServiceTest.java
@@ -1,0 +1,147 @@
+package com.palantir.docker.compose.resolve;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.nio.charset.StandardCharsets;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.common.net.InetAddresses;
+import com.palantir.docker.compose.Container;
+import com.palantir.docker.compose.DockerMachine;
+
+import sun.net.spi.nameservice.NameService;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DockerNameServiceTest {
+    private static final String MACHINE_HOST = "machine ip";
+    private static final String MACHINE_IP = "123.124.125.126";
+    private static final String SECOND_MACHINE_IP = "126.125.124.123";
+    private static final String CONTAINER_NAME = "container name";
+    private static final String SECOND_CONTAINER_NAME = "second container name";
+    private static final InetAddress[] delegateAddresses = new InetAddress[0];
+
+    @Rule
+    public final ExpectedException expected = ExpectedException.none();
+
+    @Mock
+    private NameService delegate;
+
+    @Mock
+    private Container dockerContainer;
+
+    @Mock
+    private Container secondDockerContainer;
+
+    @Mock
+    private DockerMachine dockerMachine;
+
+    @Mock
+    private DockerMachine secondDockerMachine;
+
+    private DockerNameService dockerNameService;
+
+    @Before
+    public void before() throws UnknownHostException {
+        dockerNameService = new DockerNameService(delegate);
+        when(dockerMachine.getIp()).thenReturn(MACHINE_HOST);
+        when(dockerContainer.getContainerName()).thenReturn(CONTAINER_NAME);
+        when(secondDockerContainer.getContainerName()).thenReturn(SECOND_CONTAINER_NAME);
+        when(delegate.lookupAllHostAddr(any())).thenReturn(delegateAddresses);
+    }
+
+    @After
+    public void after() {
+        DockerNameService.unregisterAll();
+    }
+
+    @Test
+    public void withNoRegistrationRequestsGoToDelegate() throws UnknownHostException {
+        assertThat(dockerNameService.lookupAllHostAddr("foo"), is(delegateAddresses));
+    }
+
+    @Test
+    public void afterRegistrationRequestsForOtherHostnamesGoToDelegate() throws UnknownHostException {
+        DockerNameService.register(dockerMachine, ImmutableSet.of(dockerContainer));
+
+        String other = "other container name";
+
+        assertThat(dockerNameService.lookupAllHostAddr(other), is(delegateAddresses));
+    }
+
+    @Test
+    public void afterRegistrationRequestsForContainerHostnameAreRewrittenToDockerMachineHost()
+            throws UnknownHostException {
+        DockerNameService.register(dockerMachine, ImmutableSet.of(dockerContainer));
+        assertThat(dockerNameService.lookupAllHostAddr(CONTAINER_NAME), is(delegateAddresses));
+    }
+
+    @Test
+    public void ifContainerAddressIsAHostnameThenTheIpIsReturnedDirectly() throws UnknownHostException {
+        when(dockerMachine.getIp()).thenReturn(MACHINE_IP);
+        DockerNameService.register(dockerMachine, ImmutableSet.of(dockerContainer));
+
+        InetAddress[] addresses = new InetAddress[] {InetAddresses.forString(MACHINE_IP)};
+
+        assertThat(dockerNameService.lookupAllHostAddr(CONTAINER_NAME), is(addresses));
+
+        verify(delegate, never()).lookupAllHostAddr(MACHINE_IP);
+    }
+
+    @Test
+    public void getHostByAddrIsPassedThrough() throws UnknownHostException {
+        byte[] data = "foo".getBytes(StandardCharsets.UTF_8);
+        String host = "host";
+        when(delegate.getHostByAddr(data)).thenReturn(host);
+        assertThat(dockerNameService.getHostByAddr(data), is(host));
+    }
+
+    @Test
+    public void canRegisterAndUseDisjointContainerSetsSimultaneously() throws UnknownHostException {
+        when(dockerMachine.getIp()).thenReturn(MACHINE_IP);
+        when(secondDockerMachine.getIp()).thenReturn(SECOND_MACHINE_IP);
+
+        InetAddress[] addresses = new InetAddress[] {InetAddresses.forString(MACHINE_IP)};
+        InetAddress[] secondAddresses = new InetAddress[] {InetAddresses.forString(SECOND_MACHINE_IP)};
+
+        DockerNameService.register(dockerMachine, ImmutableSet.of(dockerContainer));
+        DockerNameService.register(secondDockerMachine, ImmutableSet.of(secondDockerContainer));
+
+        assertThat(dockerNameService.lookupAllHostAddr(CONTAINER_NAME), is(addresses));
+        assertThat(dockerNameService.lookupAllHostAddr(SECOND_CONTAINER_NAME), is(secondAddresses));
+    }
+
+    @Test
+    public void conjointContainerSetsCauseExceptionToBeThrown() {
+        DockerNameService.register(dockerMachine, ImmutableSet.of(dockerContainer));
+
+        expected.expect(IllegalArgumentException.class);
+        DockerNameService.register(dockerMachine, ImmutableSet.of(dockerContainer));
+    }
+
+    @Test
+    public void canReregisterAndUseContainerAfterUnregistering() throws UnknownHostException {
+        DockerNameService.register(dockerMachine, ImmutableSet.of(dockerContainer));
+
+        DockerNameService.unregister(ImmutableSet.of(dockerContainer));
+
+        DockerNameService.register(dockerMachine, ImmutableSet.of(dockerContainer));
+
+        assertThat(dockerNameService.lookupAllHostAddr(CONTAINER_NAME), is(delegateAddresses));
+    }
+}


### PR DESCRIPTION
A limitation of DCR at present is that to Java, your TLS-equipped
service exists at the hostname 192.168.99.101 or wherever your
Docker machine is, and not the docker-compose hostname
(`db` or whatever). This means you can't make a proper TLS connection,
as hostname validation always fails.

This frequently leads to irritating hacks in order for normal clients to
not error - replacing the SSLSocketFactory and the HostnameValidator is
enough with OkHttp - but you frequently don't have this choice - for
example the Multipass and Gatekeeper clients force you onto their TLS
configurations. In any case, you don't want these properties to be set
in your integration tests.

We discussed all of the solutions over lunch once, and none of them were
great.

Proposed workarounds usually involve either not using TLS (which means
it can't be an ETE test), using Dash etc - which has considerable
configurational unpleasantness, or alternatively getting a cert for `localhost`,
`db`, and whatever IPs your docker machine might end up on. This is not
ideal.

Instead, this commit maintains a `NameService`, a class that Java can be
configured with to use instead of its internal DNS resolver - think of
it as a Java specific `/etc/hosts`.

It's use is entirely optional, to use it the client merely needs to set
the system property `sun.net.spi.nameservice.provider.1` to
`dns,docker-compose-rule`. When the hostname requested is not a
container, it delegates to the system dns infrastructure.

If this system property is set, the tester can communicate with the
server using the container name as the hostname. This passes
TLS validation.
