### PR TITLE
Add build badge to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+![build status](https://circleci.com/gh/palantir/docker-compose-rule.svg?style=shield&circle-token=ed5bbc06f483e3f7324d1b3440125827c8d355d7)
+
 Docker Compose JUnit Rule
 =========================
 


### PR DESCRIPTION
Create a build badge. This uses a status access token created in the CircleCI UI. It gives access to the build status to anyone, but nothing else.
