### PR TITLE
Refactor/docker composition default

### DIFF
--- a/src/main/java/com/palantir/docker/compose/DockerComposition.java
+++ b/src/main/java/com/palantir/docker/compose/DockerComposition.java
@@ -27,21 +27,6 @@
  */
 package com.palantir.docker.compose;
 
-import static java.util.stream.Collectors.toMap;
-
-import java.io.File;
-import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.concurrent.TimeUnit;
-import java.util.function.Function;
-
-import org.apache.commons.lang3.Validate;
-import org.joda.time.Duration;
-import org.junit.rules.ExternalResource;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.google.common.collect.ImmutableMap;
 import com.jayway.awaitility.Awaitility;
 import com.jayway.awaitility.core.ConditionTimeoutException;
@@ -53,6 +38,20 @@ import com.palantir.docker.compose.execution.DockerComposeExecutable;
 import com.palantir.docker.compose.logging.DoNothingLogCollector;
 import com.palantir.docker.compose.logging.FileLogCollector;
 import com.palantir.docker.compose.logging.LogCollector;
+import org.apache.commons.lang3.Validate;
+import org.joda.time.Duration;
+import org.junit.rules.ExternalResource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+
+import static java.util.stream.Collectors.toMap;
 
 public class DockerComposition extends ExternalResource {
 


### PR DESCRIPTION
Setup a default `DockerComposition` so it's not required to pass in a `DockerMachine`. It just falls back to a local machine with no additional environment variables.
