### PR TITLE
Feature/make version code make more sense

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ apply from: "gradle/idea.gradle"
 apply plugin: 'java'
 
 group = 'com.palantir.docker.compose'
-version "git describe --tags --dirty".execute().text.trim().replaceAll(/^v/, '')
+version "git describe --tags --dirty".execute().text.trim()
 
 apply plugin: 'com.palantir.baseline-checkstyle'
 apply plugin: 'com.palantir.baseline-eclipse'

--- a/circle.yml
+++ b/circle.yml
@@ -21,7 +21,7 @@ general:
 
 deployment:
   release:
-    tag: /v?[0-9]+(\.[0-9]+)+/
+    tag: /[0-9]+(\.[0-9]+)+/
     commands:
       - ./gradlew -i bintrayUpload
 

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -58,8 +58,16 @@ bintray {
 }
 
 bintrayUpload.onlyIf {
-    System.out.println("Publishing with project version: " + project.version.toString())
-    System.env.BINTRAY_USER && System.env.BINTRAY_KEY && project.version.toString() ==~ /v?\d+\.\d+\.\d+/
+    println "Attempting to publish with project version: " + project.version.toString()
+
+    def versionIsInCorrectFormat = project.version.toString() ==~ /\d+\.\d+\.\d+/
+
+    if (!versionIsInCorrectFormat) {
+      println "Cannot publish project with version " + project.version.toString() + 
+              "; it must be in form 'major.minor.patch'"
+    }
+
+    System.env.BINTRAY_USER && System.env.BINTRAY_KEY && versionIsInCorrectFormat
 }
 
 bintrayUpload.dependsOn 'generatePomFileForBintrayPublication', 'build'


### PR DESCRIPTION
Rather than stripping out the `v` prefix, try again publishing with a flat version number and hope we've managed to get circle to publish with it now.