### PR TITLE
Healthchecks should give error messages

### DIFF
--- a/src/main/java/com/palantir/docker/compose/connection/Container.java
+++ b/src/main/java/com/palantir/docker/compose/connection/Container.java
@@ -47,12 +47,18 @@ public class Container {
         return containerName;
     }
 
-    public boolean portIsListeningOnHttp(int internalPort, Function<DockerPort, String> urlFunction) {
+    public SuccessOrFailure portIsListeningOnHttp(int internalPort, Function<DockerPort, String> urlFunction) {
         try {
             DockerPort port = portMappedInternallyTo(internalPort);
-            return port.isListeningNow() && port.isHttpResponding(urlFunction);
+            if (!port.isListeningNow()) {
+                return SuccessOrFailure.failure(internalPort + " is not listening");
+            }
+            if (!port.isHttpResponding(urlFunction)) {
+                return SuccessOrFailure.failure(internalPort + " does not have a http response from " + urlFunction.apply(port));
+            }
+            return SuccessOrFailure.success();
         } catch (Exception e) {
-            return false;
+            return SuccessOrFailure.fromException(e);
         }
     }
 

--- a/src/main/java/com/palantir/docker/compose/connection/Container.java
+++ b/src/main/java/com/palantir/docker/compose/connection/Container.java
@@ -52,7 +52,6 @@ public class Container {
             DockerPort port = portMappedInternallyTo(internalPort);
             return port.isListeningNow() && port.isHttpResponding(urlFunction);
         } catch (Exception e) {
-            log.warn("Container '" + containerName + "' failed to come up: " + e.getMessage(), e);
             return false;
         }
     }

--- a/src/main/java/com/palantir/docker/compose/connection/waiting/HealthCheck.java
+++ b/src/main/java/com/palantir/docker/compose/connection/waiting/HealthCheck.java
@@ -20,5 +20,5 @@ import com.palantir.docker.compose.connection.Container;
 
 @FunctionalInterface
 public interface HealthCheck {
-    boolean isServiceUp(Container container);
+    SuccessOrFailure isServiceUp(Container container);
 }

--- a/src/main/java/com/palantir/docker/compose/connection/waiting/HealthChecks.java
+++ b/src/main/java/com/palantir/docker/compose/connection/waiting/HealthChecks.java
@@ -16,6 +16,7 @@
 
 package com.palantir.docker.compose.connection.waiting;
 
+import com.palantir.docker.compose.connection.Container;
 import com.palantir.docker.compose.connection.DockerPort;
 
 import java.util.function.Function;
@@ -26,6 +27,6 @@ public class HealthChecks {
     }
 
     public static HealthCheck toHaveAllPortsOpen() {
-        return container -> SuccessOrFailure.fromBoolean(container.areAllPortsOpen(), "better message please");
+        return Container::areAllPortsOpen;
     }
 }

--- a/src/main/java/com/palantir/docker/compose/connection/waiting/HealthChecks.java
+++ b/src/main/java/com/palantir/docker/compose/connection/waiting/HealthChecks.java
@@ -16,17 +16,16 @@
 
 package com.palantir.docker.compose.connection.waiting;
 
-import com.palantir.docker.compose.connection.Container;
 import com.palantir.docker.compose.connection.DockerPort;
 
 import java.util.function.Function;
 
 public class HealthChecks {
     public static HealthCheck toRespondOverHttp(int internalPort, Function<DockerPort, String> urlFunction) {
-        return container -> container.portIsListeningOnHttp(internalPort, urlFunction);
+        return container -> SuccessOrFailure.fromBoolean(container.portIsListeningOnHttp(internalPort, urlFunction), "Http no work");
     }
 
     public static HealthCheck toHaveAllPortsOpen() {
-        return Container::areAllPortsOpen;
+        return container -> SuccessOrFailure.fromBoolean(container.areAllPortsOpen(), "better message please");
     }
 }

--- a/src/main/java/com/palantir/docker/compose/connection/waiting/HealthChecks.java
+++ b/src/main/java/com/palantir/docker/compose/connection/waiting/HealthChecks.java
@@ -23,7 +23,7 @@ import java.util.function.Function;
 
 public class HealthChecks {
     public static HealthCheck toRespondOverHttp(int internalPort, Function<DockerPort, String> urlFunction) {
-        return container -> SuccessOrFailure.fromBoolean(container.portIsListeningOnHttp(internalPort, urlFunction), "Http no work");
+        return container -> container.portIsListeningOnHttp(internalPort, urlFunction);
     }
 
     public static HealthCheck toHaveAllPortsOpen() {

--- a/src/main/java/com/palantir/docker/compose/connection/waiting/ServiceWait.java
+++ b/src/main/java/com/palantir/docker/compose/connection/waiting/ServiceWait.java
@@ -58,7 +58,7 @@ public class ServiceWait {
                 .append("' failed to pass startup check:\n");
 
             String errorMessage = lastSuccessOrFailure.get()
-                .flatMap(SuccessOrFailure::failureMessage)
+                .flatMap(SuccessOrFailure::toOptionalFailureMessage)
                 .orElse("The healthcheck did not finish before the timeout");
 
             execptionMessage.append(errorMessage);

--- a/src/main/java/com/palantir/docker/compose/connection/waiting/ServiceWait.java
+++ b/src/main/java/com/palantir/docker/compose/connection/waiting/ServiceWait.java
@@ -65,7 +65,7 @@ public class ServiceWait {
             .flatMap(SuccessOrFailure::toOptionalFailureMessage)
             .orElse("The healthcheck did not finish before the timeout");
 
-        return String.format("Container '%s' failed to pass startup check:\n%s",
+        return String.format("Container '%s' failed to pass startup check:%n%s",
             service.getContainerName(),
             healthcheckFailureMessage);
     }

--- a/src/main/java/com/palantir/docker/compose/connection/waiting/SuccessOrFailure.java
+++ b/src/main/java/com/palantir/docker/compose/connection/waiting/SuccessOrFailure.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.palantir.docker.compose.connection.waiting;
 
 import org.apache.commons.lang3.exception.ExceptionUtils;

--- a/src/main/java/com/palantir/docker/compose/connection/waiting/SuccessOrFailure.java
+++ b/src/main/java/com/palantir/docker/compose/connection/waiting/SuccessOrFailure.java
@@ -20,7 +20,19 @@ public abstract class SuccessOrFailure {
         return optionalFailureMessage().isPresent();
     }
 
-    public String failureMessage() {
-        return optionalFailureMessage().get();
+    public boolean succeeded() {
+        return !failed();
+    }
+
+    public Optional<String> failureMessage() {
+        return optionalFailureMessage();
+    }
+
+    public static SuccessOrFailure fromBoolean(boolean succeeded, String possibleFailureMessage) {
+        if (succeeded) {
+            return success();
+        } else {
+            return failure(possibleFailureMessage);
+        }
     }
 }

--- a/src/main/java/com/palantir/docker/compose/connection/waiting/SuccessOrFailure.java
+++ b/src/main/java/com/palantir/docker/compose/connection/waiting/SuccessOrFailure.java
@@ -17,6 +17,6 @@ public abstract class SuccessOrFailure {
     }
 
     public boolean failed() {
-        return false;
+        return optionalErrorMessage().isPresent();
     }
 }

--- a/src/main/java/com/palantir/docker/compose/connection/waiting/SuccessOrFailure.java
+++ b/src/main/java/com/palantir/docker/compose/connection/waiting/SuccessOrFailure.java
@@ -1,5 +1,6 @@
 package com.palantir.docker.compose.connection.waiting;
 
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.immutables.value.Value;
 
 import java.util.Optional;
@@ -38,5 +39,9 @@ public abstract class SuccessOrFailure {
 
     public Optional<String> toOptionalFailureMessage() {
         return optionalFailureMessage();
+    }
+
+    public static SuccessOrFailure fromException(Exception exception) {
+        return SuccessOrFailure.failure("Encountered an exception: " + ExceptionUtils.getStackTrace(exception));
     }
 }

--- a/src/main/java/com/palantir/docker/compose/connection/waiting/SuccessOrFailure.java
+++ b/src/main/java/com/palantir/docker/compose/connection/waiting/SuccessOrFailure.java
@@ -16,6 +16,14 @@ public abstract class SuccessOrFailure {
         return ImmutableSuccessOrFailure.of(Optional.of(message));
     }
 
+    public static SuccessOrFailure fromBoolean(boolean succeeded, String possibleFailureMessage) {
+        if (succeeded) {
+            return success();
+        } else {
+            return failure(possibleFailureMessage);
+        }
+    }
+
     public boolean failed() {
         return optionalFailureMessage().isPresent();
     }
@@ -24,15 +32,11 @@ public abstract class SuccessOrFailure {
         return !failed();
     }
 
-    public Optional<String> failureMessage() {
-        return optionalFailureMessage();
+    public String failureMessage() {
+        return optionalFailureMessage().get();
     }
 
-    public static SuccessOrFailure fromBoolean(boolean succeeded, String possibleFailureMessage) {
-        if (succeeded) {
-            return success();
-        } else {
-            return failure(possibleFailureMessage);
-        }
+    public Optional<String> toOptionalFailureMessage() {
+        return optionalFailureMessage();
     }
 }

--- a/src/main/java/com/palantir/docker/compose/connection/waiting/SuccessOrFailure.java
+++ b/src/main/java/com/palantir/docker/compose/connection/waiting/SuccessOrFailure.java
@@ -6,7 +6,7 @@ import java.util.Optional;
 
 @Value.Immutable
 public abstract class SuccessOrFailure {
-    @Value.Parameter protected abstract Optional<String> optionalErrorMessage();
+    @Value.Parameter protected abstract Optional<String> optionalFailureMessage();
 
     public static SuccessOrFailure success() {
         return ImmutableSuccessOrFailure.of(Optional.empty());
@@ -17,6 +17,10 @@ public abstract class SuccessOrFailure {
     }
 
     public boolean failed() {
-        return optionalErrorMessage().isPresent();
+        return optionalFailureMessage().isPresent();
+    }
+
+    public String failureMessage() {
+        return optionalFailureMessage().get();
     }
 }

--- a/src/main/java/com/palantir/docker/compose/connection/waiting/SuccessOrFailure.java
+++ b/src/main/java/com/palantir/docker/compose/connection/waiting/SuccessOrFailure.java
@@ -1,0 +1,22 @@
+package com.palantir.docker.compose.connection.waiting;
+
+import org.immutables.value.Value;
+
+import java.util.Optional;
+
+@Value.Immutable
+public abstract class SuccessOrFailure {
+    @Value.Parameter protected abstract Optional<String> optionalErrorMessage();
+
+    public static SuccessOrFailure success() {
+        return ImmutableSuccessOrFailure.of(Optional.empty());
+    }
+
+    public static SuccessOrFailure failure(String message) {
+        return ImmutableSuccessOrFailure.of(Optional.of(message));
+    }
+
+    public boolean failed() {
+        return false;
+    }
+}

--- a/src/test/java/com/palantir/docker/compose/connection/ContainerTest.java
+++ b/src/test/java/com/palantir/docker/compose/connection/ContainerTest.java
@@ -23,7 +23,10 @@ import org.junit.rules.ExpectedException;
 
 import java.io.IOException;
 
+import static com.palantir.docker.compose.connection.waiting.SuccessOrFailureMatchers.failureWithMessage;
+import static com.palantir.docker.compose.connection.waiting.SuccessOrFailureMatchers.successful;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.core.Is.is;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -82,15 +85,18 @@ public class ContainerTest {
     public void have_all_ports_open_if_all_exposed_ports_are_open() throws IOException, InterruptedException {
         env.availableHttpService("service", IP, 1234, 1234);
 
-        assertThat(container.areAllPortsOpen(), is(true));
+        assertThat(container.areAllPortsOpen(), is(successful()));
     }
 
     @Test
-    public void not_have_all_ports_open_if_has_at_least_one_closed_port() throws IOException, InterruptedException {
-        env.availableService("service", IP, 1234, 1234);
-        env.unavailableService("service", IP, 4321, 4321);
+    public void not_have_all_ports_open_if_has_at_least_one_closed_port_and_report_the_name_of_the_port() throws IOException, InterruptedException {
+        int unavailablePort = 4321;
+        String unavailablePortString = Integer.toString(unavailablePort);
 
-        assertThat(container.areAllPortsOpen(), is(false));
+        env.availableService("service", IP, 1234, 1234);
+        env.unavailableService("service", IP, unavailablePort, unavailablePort);
+
+        assertThat(container.areAllPortsOpen(), is(failureWithMessage(containsString(unavailablePortString))));
     }
 
     @Test

--- a/src/test/java/com/palantir/docker/compose/connection/waiting/HttpHealthCheckShould.java
+++ b/src/test/java/com/palantir/docker/compose/connection/waiting/HttpHealthCheckShould.java
@@ -22,7 +22,6 @@ import org.junit.Test;
 
 import java.util.function.Function;
 
-import static com.palantir.docker.compose.connection.waiting.HealthChecks.toRespondOverHttp;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.mockito.Mockito.mock;
@@ -38,7 +37,7 @@ public class HttpHealthCheckShould {
         whenTheContainerIsListeningOnHttpTo(PORT, URL_FUNCTION);
 
         assertThat(
-                toRespondOverHttp(PORT, URL_FUNCTION).isServiceUp(container),
+                HealthChecks.toRespondOverHttp(PORT, URL_FUNCTION).isServiceUp(container),
                 is(SuccessOrFailure.success()));
     }
 
@@ -47,7 +46,7 @@ public class HttpHealthCheckShould {
         whenTheContainerIsNotListeningOnHttpTo(PORT, URL_FUNCTION);
 
         assertThat(
-                toRespondOverHttp(PORT, URL_FUNCTION).isServiceUp(container).failed(),
+                HealthChecks.toRespondOverHttp(PORT, URL_FUNCTION).isServiceUp(container).failed(),
                 is(true));
     }
 

--- a/src/test/java/com/palantir/docker/compose/connection/waiting/HttpHealthCheckShould.java
+++ b/src/test/java/com/palantir/docker/compose/connection/waiting/HttpHealthCheckShould.java
@@ -39,7 +39,7 @@ public class HttpHealthCheckShould {
 
         assertThat(
                 toRespondOverHttp(PORT, URL_FUNCTION).isServiceUp(container),
-                is(true));
+                is(SuccessOrFailure.success()));
     }
 
     @Test
@@ -47,8 +47,8 @@ public class HttpHealthCheckShould {
         whenTheContainerIsNotListeningOnHttpTo(PORT, URL_FUNCTION);
 
         assertThat(
-                toRespondOverHttp(PORT, URL_FUNCTION).isServiceUp(container),
-                is(false));
+                toRespondOverHttp(PORT, URL_FUNCTION).isServiceUp(container).failed(),
+                is(true));
     }
 
     private void whenTheContainerIsListeningOnHttpTo(int port, Function<DockerPort, String> urlFunction) {

--- a/src/test/java/com/palantir/docker/compose/connection/waiting/HttpHealthCheckShould.java
+++ b/src/test/java/com/palantir/docker/compose/connection/waiting/HttpHealthCheckShould.java
@@ -22,6 +22,8 @@ import org.junit.Test;
 
 import java.util.function.Function;
 
+import static com.palantir.docker.compose.connection.waiting.SuccessOrFailureMatchers.failure;
+import static com.palantir.docker.compose.connection.waiting.SuccessOrFailureMatchers.successful;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.mockito.Mockito.mock;
@@ -38,7 +40,7 @@ public class HttpHealthCheckShould {
 
         assertThat(
                 HealthChecks.toRespondOverHttp(PORT, URL_FUNCTION).isServiceUp(container),
-                is(SuccessOrFailure.success()));
+                is(successful()));
     }
 
     @Test
@@ -46,16 +48,16 @@ public class HttpHealthCheckShould {
         whenTheContainerIsNotListeningOnHttpTo(PORT, URL_FUNCTION);
 
         assertThat(
-                HealthChecks.toRespondOverHttp(PORT, URL_FUNCTION).isServiceUp(container).failed(),
-                is(true));
+                HealthChecks.toRespondOverHttp(PORT, URL_FUNCTION).isServiceUp(container),
+                is(failure()));
     }
 
     private void whenTheContainerIsListeningOnHttpTo(int port, Function<DockerPort, String> urlFunction) {
-        when(container.portIsListeningOnHttp(port, urlFunction)).thenReturn(true);
+        when(container.portIsListeningOnHttp(port, urlFunction)).thenReturn(SuccessOrFailure.success());
     }
 
     private void whenTheContainerIsNotListeningOnHttpTo(int port, Function<DockerPort, String> urlFunction) {
-        when(container.portIsListeningOnHttp(port, urlFunction)).thenReturn(false);
+        when(container.portIsListeningOnHttp(port, urlFunction)).thenReturn(SuccessOrFailure.failure("not listening"));
     }
 
 }

--- a/src/test/java/com/palantir/docker/compose/connection/waiting/PortsHealthCheckShould.java
+++ b/src/test/java/com/palantir/docker/compose/connection/waiting/PortsHealthCheckShould.java
@@ -31,14 +31,14 @@ public class PortsHealthCheckShould {
     public void be_healthy_when_all_ports_are_listening() {
         whenTheContainerHasAllPortsOpen();
 
-        assertThat(healthCheck.isServiceUp(container), is(true));
+        assertThat(healthCheck.isServiceUp(container), is(SuccessOrFailure.success()));
     }
 
     @Test
     public void be_unhealthy_when_all_ports_are_not_listening() {
         whenTheContainerDoesNotHaveAllPortsOpen();
 
-        assertThat(healthCheck.isServiceUp(container), is(false));
+        assertThat(healthCheck.isServiceUp(container).failed(), is(true));
     }
 
     private void whenTheContainerDoesNotHaveAllPortsOpen() {

--- a/src/test/java/com/palantir/docker/compose/connection/waiting/PortsHealthCheckShould.java
+++ b/src/test/java/com/palantir/docker/compose/connection/waiting/PortsHealthCheckShould.java
@@ -18,6 +18,8 @@ package com.palantir.docker.compose.connection.waiting;
 import com.palantir.docker.compose.connection.Container;
 import org.junit.Test;
 
+import static com.palantir.docker.compose.connection.waiting.SuccessOrFailureMatchers.failure;
+import static com.palantir.docker.compose.connection.waiting.SuccessOrFailureMatchers.successful;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.mockito.Mockito.mock;
@@ -31,21 +33,21 @@ public class PortsHealthCheckShould {
     public void be_healthy_when_all_ports_are_listening() {
         whenTheContainerHasAllPortsOpen();
 
-        assertThat(healthCheck.isServiceUp(container), is(SuccessOrFailure.success()));
+        assertThat(healthCheck.isServiceUp(container), is(successful()));
     }
 
     @Test
     public void be_unhealthy_when_all_ports_are_not_listening() {
         whenTheContainerDoesNotHaveAllPortsOpen();
 
-        assertThat(healthCheck.isServiceUp(container).failed(), is(true));
+        assertThat(healthCheck.isServiceUp(container), is(failure()));
     }
 
     private void whenTheContainerDoesNotHaveAllPortsOpen() {
-        when(container.areAllPortsOpen()).thenReturn(false);
+        when(container.areAllPortsOpen()).thenReturn(SuccessOrFailure.failure("not all ports open"));
     }
 
     private void whenTheContainerHasAllPortsOpen() {
-        when(container.areAllPortsOpen()).thenReturn(true);
+        when(container.areAllPortsOpen()).thenReturn(SuccessOrFailure.success());
     }
 }

--- a/src/test/java/com/palantir/docker/compose/connection/waiting/SuccessOrFailureMatchers.java
+++ b/src/test/java/com/palantir/docker/compose/connection/waiting/SuccessOrFailureMatchers.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.palantir.docker.compose.connection.waiting;
 
 import org.hamcrest.Description;

--- a/src/test/java/com/palantir/docker/compose/connection/waiting/SuccessOrFailureMatchers.java
+++ b/src/test/java/com/palantir/docker/compose/connection/waiting/SuccessOrFailureMatchers.java
@@ -1,0 +1,64 @@
+package com.palantir.docker.compose.connection.waiting;
+
+import org.hamcrest.Description;
+import org.hamcrest.FeatureMatcher;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+
+import static org.hamcrest.Matchers.anything;
+import static org.hamcrest.Matchers.equalTo;
+
+public enum SuccessOrFailureMatchers {;
+    public static class Successful extends TypeSafeDiagnosingMatcher<SuccessOrFailure> {
+        @Override
+        protected boolean matchesSafely(SuccessOrFailure item, Description mismatchDescription) {
+            if (item.failed()) {
+                mismatchDescription.appendValue(item);
+            }
+
+            return item.succeeded();
+        }
+
+        @Override
+        public void describeTo(Description description) {
+            description.appendText("is successful");
+        }
+    }
+
+    public static Matcher<SuccessOrFailure> successful() {
+        return new Successful();
+    }
+
+    public static class Failure extends FeatureMatcher<SuccessOrFailure, String> {
+        public Failure(Matcher<? super String> subMatcher) {
+            super(subMatcher, "failure message of", "failure message");
+        }
+
+        @Override
+        protected String featureValueOf(SuccessOrFailure actual) {
+            return actual.failureMessage();
+        }
+
+        @Override
+        protected boolean matchesSafely(SuccessOrFailure actual, Description mismatch) {
+            if (actual.succeeded()) {
+                mismatch.appendValue(actual);
+                return false;
+            }
+
+            return super.matchesSafely(actual, mismatch);
+        }
+    }
+
+    public static Matcher<SuccessOrFailure> failure() {
+        return new Failure(anything());
+    }
+
+    public static Matcher<SuccessOrFailure> failureWithMessage(Matcher<String> messageMatcher) {
+        return new Failure(messageMatcher);
+    }
+
+    public static Matcher<SuccessOrFailure> failureWithMessage(String message) {
+        return new Failure(equalTo(message));
+    }
+}

--- a/src/test/java/com/palantir/docker/compose/connection/waiting/SuccessOrFailureShould.java
+++ b/src/test/java/com/palantir/docker/compose/connection/waiting/SuccessOrFailureShould.java
@@ -1,0 +1,13 @@
+package com.palantir.docker.compose.connection.waiting;
+
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+
+public class SuccessOrFailureShould {
+    @Test
+    public void not_have_failed_if_actually_a_success() {
+        assertThat(SuccessOrFailure.success().failed(), is(false));
+    }
+}

--- a/src/test/java/com/palantir/docker/compose/connection/waiting/SuccessOrFailureShould.java
+++ b/src/test/java/com/palantir/docker/compose/connection/waiting/SuccessOrFailureShould.java
@@ -15,4 +15,14 @@ public class SuccessOrFailureShould {
     public void have_failed_if_actually_a_failure() {
         assertThat(SuccessOrFailure.failure("oops").failed(), is(true));
     }
+
+    @Test
+    public void return_the_failure_message_if_set() {
+        assertThat(SuccessOrFailure.failure("oops").failureMessage(), is("oops"));
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void throw_an_exception_if_trying_to_get_the_failure_message_for_a_success() {
+        SuccessOrFailure.success().failureMessage();
+    }
 }

--- a/src/test/java/com/palantir/docker/compose/connection/waiting/SuccessOrFailureShould.java
+++ b/src/test/java/com/palantir/docker/compose/connection/waiting/SuccessOrFailureShould.java
@@ -2,6 +2,8 @@ package com.palantir.docker.compose.connection.waiting;
 
 import org.junit.Test;
 
+import java.util.Optional;
+
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 
@@ -18,11 +20,6 @@ public class SuccessOrFailureShould {
 
     @Test
     public void return_the_failure_message_if_set() {
-        assertThat(SuccessOrFailure.failure("oops").failureMessage(), is("oops"));
-    }
-
-    @Test(expected = RuntimeException.class)
-    public void throw_an_exception_if_trying_to_get_the_failure_message_for_a_success() {
-        SuccessOrFailure.success().failureMessage();
+        assertThat(SuccessOrFailure.failure("oops").failureMessage(), is(Optional.of("oops")));
     }
 }

--- a/src/test/java/com/palantir/docker/compose/connection/waiting/SuccessOrFailureShould.java
+++ b/src/test/java/com/palantir/docker/compose/connection/waiting/SuccessOrFailureShould.java
@@ -10,4 +10,9 @@ public class SuccessOrFailureShould {
     public void not_have_failed_if_actually_a_success() {
         assertThat(SuccessOrFailure.success().failed(), is(false));
     }
+
+    @Test
+    public void have_failed_if_actually_a_failure() {
+        assertThat(SuccessOrFailure.failure("oops").failed(), is(true));
+    }
 }

--- a/src/test/java/com/palantir/docker/compose/connection/waiting/SuccessOrFailureShould.java
+++ b/src/test/java/com/palantir/docker/compose/connection/waiting/SuccessOrFailureShould.java
@@ -2,24 +2,25 @@ package com.palantir.docker.compose.connection.waiting;
 
 import org.junit.Test;
 
-import java.util.Optional;
-
+import static com.palantir.docker.compose.connection.waiting.SuccessOrFailureMatchers.failure;
+import static com.palantir.docker.compose.connection.waiting.SuccessOrFailureMatchers.failureWithMessage;
+import static com.palantir.docker.compose.connection.waiting.SuccessOrFailureMatchers.successful;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 
 public class SuccessOrFailureShould {
     @Test
     public void not_have_failed_if_actually_a_success() {
-        assertThat(SuccessOrFailure.success().failed(), is(false));
+        assertThat(SuccessOrFailure.success(), is(successful()));
     }
 
     @Test
     public void have_failed_if_actually_a_failure() {
-        assertThat(SuccessOrFailure.failure("oops").failed(), is(true));
+        assertThat(SuccessOrFailure.failure("oops"), is(failure()));
     }
 
     @Test
     public void return_the_failure_message_if_set() {
-        assertThat(SuccessOrFailure.failure("oops").failureMessage(), is(Optional.of("oops")));
+        assertThat(SuccessOrFailure.failure("oops"), is(failureWithMessage("oops")));
     }
 }

--- a/src/test/java/com/palantir/docker/compose/connection/waiting/SuccessOrFailureShould.java
+++ b/src/test/java/com/palantir/docker/compose/connection/waiting/SuccessOrFailureShould.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.palantir.docker.compose.connection.waiting;
 
 import org.junit.Test;

--- a/src/test/java/com/palantir/docker/compose/connection/waiting/SuccessOrFailureShould.java
+++ b/src/test/java/com/palantir/docker/compose/connection/waiting/SuccessOrFailureShould.java
@@ -6,6 +6,8 @@ import static com.palantir.docker.compose.connection.waiting.SuccessOrFailureMat
 import static com.palantir.docker.compose.connection.waiting.SuccessOrFailureMatchers.failureWithMessage;
 import static com.palantir.docker.compose.connection.waiting.SuccessOrFailureMatchers.successful;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.both;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.core.Is.is;
 
 public class SuccessOrFailureShould {
@@ -22,5 +24,15 @@ public class SuccessOrFailureShould {
     @Test
     public void return_the_failure_message_if_set() {
         assertThat(SuccessOrFailure.failure("oops"), is(failureWithMessage("oops")));
+    }
+
+    @Test
+    public void fail_from_an_exception() {
+        Exception exception = new RuntimeException("oh no");
+        assertThat(SuccessOrFailure.fromException(exception),
+            is(failureWithMessage(both(
+                containsString("RuntimeException")).and(
+                containsString("oh no")
+            ))));
     }
 }


### PR DESCRIPTION
Tired of just seeing `Container 'myContainer' failed to pass startup check` rather than *why* it failed the startup check, I've now made it so that healthchecks return an error as well as if it succeeded or failed.