### PR TITLE
Put `docker-compose` output directly into exception message

### DIFF
--- a/src/main/java/com/palantir/docker/compose/execution/DefaultDockerCompose.java
+++ b/src/main/java/com/palantir/docker/compose/execution/DefaultDockerCompose.java
@@ -118,10 +118,10 @@ public class DefaultDockerCompose implements DockerCompose {
 
     private ErrorHandler throwingOnError() {
         return (exitCode, output, commands) -> {
-            log.warn(constructNonZeroExitErrorMessage(exitCode, commands));
-            log.warn("The output was:");
-            log.warn(output);
-            throw new DockerComposeExecutionException(constructNonZeroExitErrorMessage(exitCode, commands));
+            String message = constructNonZeroExitErrorMessage(exitCode, commands) + "\n"
+                + "The output was:\n"
+                + output;
+            throw new DockerComposeExecutionException(message);
         };
     }
 


### PR DESCRIPTION
Currently my build platform gives me the exception message in one block in a nice place. Logging the output separately to exception means I have to hunt it down in the logs. This way the output is included with the exception so you can easily debug.