### PR TITLE
Feature/fix container log output for docker compose 1 7

### DIFF
--- a/src/test/java/com/palantir/docker/compose/execution/DockerComposeTest.java
+++ b/src/test/java/com/palantir/docker/compose/execution/DockerComposeTest.java
@@ -79,10 +79,23 @@ public class DockerComposeTest {
 
     @Test
     public void logs_calls_docker_compose_with_no_colour_flag() throws IOException, InterruptedException {
-        when(executedProcess.getInputStream()).thenReturn(toInputStream("logs"));
+        when(executedProcess.getInputStream()).thenReturn(
+                toInputStream("docker-compose version 1.5.6, build 1ad8866"),
+                toInputStream("logs"));
         ByteArrayOutputStream output = new ByteArrayOutputStream();
         compose.writeLogs("db", output);
         verify(executor).execute("logs", "--no-color", "db");
+        assertThat(new String(output.toByteArray(), StandardCharsets.UTF_8), is("logs"));
+    }
+
+    @Test
+    public void logs_calls_docker_compose_with_the_follow_flag_when_the_version_is_at_least_1_7_0() throws IOException, InterruptedException {
+        when(executedProcess.getInputStream()).thenReturn(
+                toInputStream("docker-compose version 1.7.0, build 1ad8866"),
+                toInputStream("logs"));
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        compose.writeLogs("db", output);
+        verify(executor).execute("logs", "--no-color", "--follow", "db");
         assertThat(new String(output.toByteArray(), StandardCharsets.UTF_8), is("logs"));
     }
 

--- a/src/test/java/com/palantir/docker/compose/execution/DockerComposeVersionTest.java
+++ b/src/test/java/com/palantir/docker/compose/execution/DockerComposeVersionTest.java
@@ -43,6 +43,8 @@ public class DockerComposeVersionTest {
 
     @Test
     public void remove_non_digits_when_passing_version_string() {
-        assertEquals(Version.valueOf("1.7.0"), DockerComposeVersion.parseFromDockerComposeVersion("docker-compose version 1.7.0rc1, build 1ad8866"));
+        assertEquals(
+                DockerComposeVersion.parseFromDockerComposeVersion("docker-compose version 1.7.0rc1, build 1ad8866"),
+                Version.valueOf("1.7.0"));
     }
 }

--- a/src/test/java/com/palantir/docker/compose/logging/DockerCompositionLoggingIntegrationTest.java
+++ b/src/test/java/com/palantir/docker/compose/logging/DockerCompositionLoggingIntegrationTest.java
@@ -16,7 +16,7 @@
 package com.palantir.docker.compose.logging;
 
 import static com.palantir.docker.compose.connection.waiting.HealthChecks.toHaveAllPortsOpen;
-import static com.palantir.docker.compose.matchers.IOMatchers.file;
+import static com.palantir.docker.compose.matchers.IOMatchers.fileWithConents;
 import static com.palantir.docker.compose.matchers.IOMatchers.matchingPattern;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
@@ -53,8 +53,10 @@ public class DockerCompositionLoggingIntegrationTest {
         } finally {
             loggingComposition.after();
         }
-        assertThat(new File(logFolder.getRoot(), "db.log"), is(file(matchingPattern(".*Attaching to \\w+_db_1.*"))));
-        assertThat(new File(logFolder.getRoot(), "db2.log"), is(file(matchingPattern(".*Attaching to \\w+_db2_1.*"))));
+        assertThat(new File(logFolder.getRoot(), "db.log"), is(fileWithConents(matchingPattern(
+                ".*Attaching to \\w+_db_1.*server started.*"))));
+        assertThat(new File(logFolder.getRoot(), "db2.log"), is(fileWithConents(matchingPattern(
+                ".*Attaching to \\w+_db2_1.*server started.*"))));
     }
 
 }

--- a/src/test/java/com/palantir/docker/compose/matchers/IOMatchers.java
+++ b/src/test/java/com/palantir/docker/compose/matchers/IOMatchers.java
@@ -84,7 +84,7 @@ public final class IOMatchers {
     }
 
     public static Matcher<File> fileContainingString(String contents) {
-        return file(containsString(contents));
+        return fileWithConents(containsString(contents));
     }
 
     public static Matcher<String> matchingPattern(String patternStr) {
@@ -94,7 +94,7 @@ public final class IOMatchers {
                 Pattern pattern = Pattern.compile(patternStr, Pattern.DOTALL);
                 boolean matches = pattern.matcher(text).matches();
                 if (!matches) {
-                    mismatchDescription.appendText("not matching " + patternStr);
+                    mismatchDescription.appendText(text);
                 }
                 return matches;
             }
@@ -106,7 +106,7 @@ public final class IOMatchers {
         };
     }
 
-    public static Matcher<File> file(Matcher<String> contentsMatcher) {
+    public static Matcher<File> fileWithConents(Matcher<String> contentsMatcher) {
         return new FeatureMatcher<File, String>(contentsMatcher, "file contents", "file contents") {
 
             @Override


### PR DESCRIPTION
Logs were not being saved correctly due to the breaking change in docker-compose 1.7.0 (https://github.com/docker/compose/releases/tag/1.7.0)