### PR TITLE
Allow DockerType to be specified in localMachine

### DIFF
--- a/src/main/java/com/palantir/docker/compose/configuration/DockerType.java
+++ b/src/main/java/com/palantir/docker/compose/configuration/DockerType.java
@@ -15,15 +15,16 @@
  */
 package com.palantir.docker.compose.configuration;
 
+import com.google.common.base.StandardSystemProperty;
+
 public enum DockerType {
 
     DAEMON, REMOTE;
 
-    public static final String OS_NAME = "os.name";
     public static final String MAC_OS = "Mac";
 
-    public static DockerType getLocalDockerType() {
-        if (System.getProperty(OS_NAME, "").startsWith(MAC_OS)) {
+    public static DockerType getDefaultLocalDockerType() {
+        if (StandardSystemProperty.OS_NAME.value().startsWith(MAC_OS)) {
             return REMOTE;
         } else {
             return DAEMON;

--- a/src/main/java/com/palantir/docker/compose/connection/DockerMachine.java
+++ b/src/main/java/com/palantir/docker/compose/connection/DockerMachine.java
@@ -59,7 +59,11 @@ public class DockerMachine implements DockerConfiguration {
     }
 
     public static LocalBuilder localMachine() {
-        return new LocalBuilder(DockerType.getLocalDockerType(), System.getenv());
+        return localMachine(DockerType.getDefaultLocalDockerType());
+    }
+
+    public static LocalBuilder localMachine(DockerType dockerType) {
+        return new LocalBuilder(dockerType, System.getenv());
     }
 
     public static class LocalBuilder {

--- a/src/test/java/com/palantir/docker/compose/configuration/DockerTypeTest.java
+++ b/src/test/java/com/palantir/docker/compose/configuration/DockerTypeTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.docker.compose.configuration;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assume.assumeFalse;
+import static org.junit.Assume.assumeTrue;
+
+import com.google.common.base.StandardSystemProperty;
+import org.junit.Test;
+
+public class DockerTypeTest {
+
+    @Test
+    public void testDefaultDockerTypeForMacIsRemote() {
+        assumeTrue("Running on a non-Mac system; skipping Mac unit test",
+                StandardSystemProperty.OS_NAME.value().startsWith(DockerType.MAC_OS));
+        assertThat(DockerType.REMOTE, is(DockerType.getDefaultLocalDockerType()));
+    }
+
+    @Test
+    public void testDefaultDockerTypeForNonMacIsDaemon() {
+        assumeFalse("Running on a Mac system; skipping non-Mac unit test",
+                StandardSystemProperty.OS_NAME.value().startsWith(DockerType.MAC_OS));
+        assertThat(DockerType.DAEMON, is(DockerType.getDefaultLocalDockerType()));
+    }
+
+}


### PR DESCRIPTION
Fixes #68 by providing ability to set LocalMachine
to be explicitly set to DAEMON regardless of platform.