### PR TITLE
Don't assume that an SSL exception when health checking a container means it's up.

### DIFF
--- a/src/main/java/com/palantir/docker/compose/connection/DockerPort.java
+++ b/src/main/java/com/palantir/docker/compose/connection/DockerPort.java
@@ -87,8 +87,8 @@ public class DockerPort {
             log.debug("Received 404, assuming port active");
             return true;
         } catch (SSLHandshakeException e) {
-            log.debug("Received SSL response, assuming port active");
-            return true;
+            log.debug("Received bad SSL response, assuming port inactive");
+            return false;
         } catch (IOException e) {
             log.trace("Error acquiring http connection, assuming port open but inactive", e);
             return false;


### PR DESCRIPTION
A service can open a port before it's ready to accept SSL connections.

Not sure how I'd go about testing this one.