### PR TITLE
do not prevent jvm shutdown due to empty thread pools

### DIFF
--- a/src/main/java/com/palantir/docker/compose/execution/Command.java
+++ b/src/main/java/com/palantir/docker/compose/execution/Command.java
@@ -26,6 +26,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.util.Arrays;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -68,12 +69,14 @@ public class Command {
     private ProcessResult run(String... commands) throws IOException, InterruptedException {
         Process process = executable.execute(commands);
 
-        Future<String> outputProcessing = newSingleThreadExecutor()
+        ExecutorService exec = newSingleThreadExecutor();
+        Future<String> outputProcessing = exec
                 .submit(() -> processOutputFrom(process));
 
         String output = waitForResultFrom(outputProcessing);
 
         process.waitFor(MINUTES_TO_WAIT_AFTER_STD_OUT_CLOSES, TimeUnit.MINUTES);
+        exec.shutdown();
 
         return new ProcessResult(process.exitValue(), output);
     }

--- a/src/test/java/com/palantir/docker/compose/execution/CommandShould.java
+++ b/src/test/java/com/palantir/docker/compose/execution/CommandShould.java
@@ -96,6 +96,14 @@ public class CommandShould {
         assertThat(consumedLogLines, contains("line 1", "line 2"));
     }
 
+    @Test public void
+    not_create_long_lived_threads_after_execution() throws IOException, InterruptedException {
+        int preThreadCount = Thread.getAllStackTraces().entrySet().size();
+        dockerComposeCommand.execute(errorHandler, "rm", "-f");
+        int postThreadCount = Thread.getAllStackTraces().entrySet().size();
+        assertThat("command thread pool has exited", preThreadCount == postThreadCount);
+    }
+
     private void givenTheUnderlyingProcessHasOutput(String output) {
         when(executedProcess.getInputStream()).thenReturn(toInputStream(output));
     }


### PR DESCRIPTION
I was trying to use docker-compose-rule with [Java Microbenchmarking Harness (JMH)](http://openjdk.java.net/projects/code-tools/jmh/) and found that docker-compose-rule uses non-daemon threads (probably okay) and does not explicitly shutdown these associated pools (probably bad).  I hit this with JMH because JMH forks JVMs and complains when the spawned JVMs do not shutdown normally.  The project (the one using JMH) uses docker-compose-rule in non-test code (probably not how it was originally intended), but everything else worked smoothly minus this particular hiccup.