### PR TITLE
Add support for calling docker-compose run

### DIFF
--- a/src/main/java/com/palantir/docker/compose/DockerComposeRule.java
+++ b/src/main/java/com/palantir/docker/compose/DockerComposeRule.java
@@ -24,6 +24,8 @@ import com.palantir.docker.compose.execution.DockerCompose;
 import com.palantir.docker.compose.execution.DockerComposeExecArgument;
 import com.palantir.docker.compose.execution.DockerComposeExecOption;
 import com.palantir.docker.compose.execution.DockerComposeExecutable;
+import com.palantir.docker.compose.execution.DockerComposeRunArgument;
+import com.palantir.docker.compose.execution.DockerComposeRunOption;
 import com.palantir.docker.compose.execution.DockerExecutable;
 import com.palantir.docker.compose.execution.RetryingDockerCompose;
 import com.palantir.docker.compose.logging.DoNothingLogCollector;
@@ -163,6 +165,11 @@ public abstract class DockerComposeRule extends ExternalResource {
     public String exec(DockerComposeExecOption options, String containerName,
             DockerComposeExecArgument arguments) throws IOException, InterruptedException {
         return dockerCompose().exec(options, containerName, arguments);
+    }
+
+    public String run(DockerComposeRunOption options, String containerName,
+            DockerComposeRunArgument arguments) throws IOException, InterruptedException {
+        return dockerCompose().run(options, containerName, arguments);
     }
 
     public static ImmutableDockerComposeRule.Builder builder() {

--- a/src/main/java/com/palantir/docker/compose/DockerComposition.java
+++ b/src/main/java/com/palantir/docker/compose/DockerComposition.java
@@ -22,6 +22,8 @@ import com.palantir.docker.compose.connection.DockerPort;
 import com.palantir.docker.compose.execution.DockerCompose;
 import com.palantir.docker.compose.execution.DockerComposeExecArgument;
 import com.palantir.docker.compose.execution.DockerComposeExecOption;
+import com.palantir.docker.compose.execution.DockerComposeRunArgument;
+import com.palantir.docker.compose.execution.DockerComposeRunOption;
 import java.io.IOException;
 import org.junit.rules.ExternalResource;
 
@@ -99,6 +101,11 @@ public class DockerComposition extends ExternalResource {
     public String exec(DockerComposeExecOption options, String containerName, DockerComposeExecArgument arguments)
             throws IOException, InterruptedException {
         return rule.exec(options, containerName, arguments);
+    }
+
+    public String run(DockerComposeRunOption options, String containerName, DockerComposeRunArgument arguments)
+            throws IOException, InterruptedException {
+        return rule.run(options, containerName, arguments);
     }
 
     public DockerPort hostNetworkedPort(int port) {

--- a/src/main/java/com/palantir/docker/compose/execution/DefaultDockerCompose.java
+++ b/src/main/java/com/palantir/docker/compose/execution/DefaultDockerCompose.java
@@ -103,6 +103,13 @@ public class DefaultDockerCompose implements DockerCompose {
         return command.execute(Command.throwingOnError(), fullArgs);
     }
 
+    @Override
+    public String run(DockerComposeRunOption dockerComposeRunOption, String containerName,
+            DockerComposeRunArgument dockerComposeRunArgument) throws IOException, InterruptedException {
+        String[] fullArgs = constructFullDockerComposeRunArguments(dockerComposeRunOption, containerName, dockerComposeRunArgument);
+        return command.execute(Command.throwingOnError(), fullArgs);
+    }
+
     private void verifyDockerComposeVersionAtLeast(Version targetVersion, String message) throws IOException, InterruptedException {
         validState(version().greaterThanOrEqualTo(targetVersion), message);
     }
@@ -119,6 +126,16 @@ public class DefaultDockerCompose implements DockerCompose {
                                                                             .add(containerName)
                                                                             .addAll(dockerComposeExecArgument.asList())
                                                                             .build();
+        return fullArgs.toArray(new String[fullArgs.size()]);
+    }
+
+    private String[] constructFullDockerComposeRunArguments(DockerComposeRunOption dockerComposeRunOption,
+            String containerName, DockerComposeRunArgument dockerComposeRunArgument) {
+        ImmutableList<String> fullArgs = new ImmutableList.Builder<String>().add("run")
+                .addAll(dockerComposeRunOption.asList())
+                .add(containerName)
+                .addAll(dockerComposeRunArgument.asList())
+                .build();
         return fullArgs.toArray(new String[fullArgs.size()]);
     }
 

--- a/src/main/java/com/palantir/docker/compose/execution/DefaultDockerCompose.java
+++ b/src/main/java/com/palantir/docker/compose/execution/DefaultDockerCompose.java
@@ -122,9 +122,9 @@ public class DefaultDockerCompose implements DockerCompose {
     private String[] constructFullDockerComposeExecArguments(DockerComposeExecOption dockerComposeExecOption,
             String containerName, DockerComposeExecArgument dockerComposeExecArgument) {
         ImmutableList<String> fullArgs = new ImmutableList.Builder<String>().add("exec")
-                                                                            .addAll(dockerComposeExecOption.asList())
+                                                                            .addAll(dockerComposeExecOption.options())
                                                                             .add(containerName)
-                                                                            .addAll(dockerComposeExecArgument.asList())
+                                                                            .addAll(dockerComposeExecArgument.arguments())
                                                                             .build();
         return fullArgs.toArray(new String[fullArgs.size()]);
     }
@@ -132,9 +132,9 @@ public class DefaultDockerCompose implements DockerCompose {
     private String[] constructFullDockerComposeRunArguments(DockerComposeRunOption dockerComposeRunOption,
             String containerName, DockerComposeRunArgument dockerComposeRunArgument) {
         ImmutableList<String> fullArgs = new ImmutableList.Builder<String>().add("run")
-                .addAll(dockerComposeRunOption.asList())
+                .addAll(dockerComposeRunOption.options())
                 .add(containerName)
-                .addAll(dockerComposeRunArgument.asList())
+                .addAll(dockerComposeRunArgument.arguments())
                 .build();
         return fullArgs.toArray(new String[fullArgs.size()]);
     }

--- a/src/main/java/com/palantir/docker/compose/execution/DelegatingDockerCompose.java
+++ b/src/main/java/com/palantir/docker/compose/execution/DelegatingDockerCompose.java
@@ -71,6 +71,12 @@ abstract class DelegatingDockerCompose implements DockerCompose {
     }
 
     @Override
+    public String run(DockerComposeRunOption dockerComposeRunOption, String containerName,
+            DockerComposeRunArgument dockerComposeRunArgument) throws IOException, InterruptedException {
+        return dockerCompose.run(dockerComposeRunOption, containerName, dockerComposeRunArgument);
+    }
+
+    @Override
     public ContainerNames ps() throws IOException, InterruptedException {
         return dockerCompose.ps();
     }

--- a/src/main/java/com/palantir/docker/compose/execution/DockerCompose.java
+++ b/src/main/java/com/palantir/docker/compose/execution/DockerCompose.java
@@ -31,6 +31,7 @@ public interface DockerCompose {
     void start(Container container) throws IOException, InterruptedException;
     void stop(Container container) throws IOException, InterruptedException;
     String exec(DockerComposeExecOption dockerComposeExecOption, String containerName, DockerComposeExecArgument dockerComposeExecArgument) throws IOException, InterruptedException;
+    String run(DockerComposeRunOption dockerComposeRunOption, String containerName, DockerComposeRunArgument dockerComposeRunArgument) throws IOException, InterruptedException;
     ContainerNames ps() throws IOException, InterruptedException;
     Container container(String containerName);
     boolean writeLogs(String container, OutputStream output) throws IOException;

--- a/src/main/java/com/palantir/docker/compose/execution/DockerComposeExecArgument.java
+++ b/src/main/java/com/palantir/docker/compose/execution/DockerComposeExecArgument.java
@@ -17,20 +17,14 @@ package com.palantir.docker.compose.execution;
 
 import java.util.Arrays;
 import java.util.List;
-
 import org.immutables.value.Value;
 
 @Value.Immutable
 public abstract class DockerComposeExecArgument {
-
     @Value.Parameter
-    protected abstract String[] arguments();
+    public abstract List<String> arguments();
 
     public static DockerComposeExecArgument arguments(String... arguments) {
-        return ImmutableDockerComposeExecArgument.of(arguments);
-    }
-
-    public List<String> asList() {
-        return Arrays.asList(arguments());
+        return ImmutableDockerComposeExecArgument.of(Arrays.asList(arguments));
     }
 }

--- a/src/main/java/com/palantir/docker/compose/execution/DockerComposeExecOption.java
+++ b/src/main/java/com/palantir/docker/compose/execution/DockerComposeExecOption.java
@@ -22,15 +22,10 @@ import org.immutables.value.Value;
 
 @Value.Immutable
 public abstract class DockerComposeExecOption {
-
     @Value.Parameter
-    protected abstract String[] options();
+    public abstract List<String> options();
 
     public static DockerComposeExecOption options(String... options) {
-        return ImmutableDockerComposeExecOption.of(options);
-    }
-
-    public List<String> asList() {
-        return Arrays.asList(options());
+        return ImmutableDockerComposeExecOption.of(Arrays.asList(options));
     }
 }

--- a/src/main/java/com/palantir/docker/compose/execution/DockerComposeRunArgument.java
+++ b/src/main/java/com/palantir/docker/compose/execution/DockerComposeRunArgument.java
@@ -22,13 +22,9 @@ import org.immutables.value.Value;
 @Value.Immutable
 public abstract class DockerComposeRunArgument {
     @Value.Parameter
-    protected abstract String[] arguments();
+    public abstract List<String> arguments();
 
     public static DockerComposeRunArgument arguments(String... arguments) {
-        return ImmutableDockerComposeRunArgument.of(arguments);
-    }
-
-    public List<String> asList() {
-        return Arrays.asList(arguments());
+        return ImmutableDockerComposeRunArgument.of(Arrays.asList(arguments));
     }
 }

--- a/src/main/java/com/palantir/docker/compose/execution/DockerComposeRunArgument.java
+++ b/src/main/java/com/palantir/docker/compose/execution/DockerComposeRunArgument.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.docker.compose.execution;
+
+import java.util.Arrays;
+import java.util.List;
+import org.immutables.value.Value;
+
+@Value.Immutable
+public abstract class DockerComposeRunArgument {
+    @Value.Parameter
+    protected abstract String[] arguments();
+
+    public static DockerComposeRunArgument arguments(String... arguments) {
+        return ImmutableDockerComposeRunArgument.of(arguments);
+    }
+
+    public List<String> asList() {
+        return Arrays.asList(arguments());
+    }
+}

--- a/src/main/java/com/palantir/docker/compose/execution/DockerComposeRunOption.java
+++ b/src/main/java/com/palantir/docker/compose/execution/DockerComposeRunOption.java
@@ -22,13 +22,9 @@ import org.immutables.value.Value;
 @Value.Immutable
 public abstract class DockerComposeRunOption {
     @Value.Parameter
-    protected abstract String[] options();
+    public abstract List<String> options();
 
     public static DockerComposeRunOption options(String... options) {
-        return ImmutableDockerComposeRunOption.of(options);
-    }
-
-    public List<String> asList() {
-        return Arrays.asList(options());
+        return ImmutableDockerComposeRunOption.of(Arrays.asList(options));
     }
 }

--- a/src/main/java/com/palantir/docker/compose/execution/DockerComposeRunOption.java
+++ b/src/main/java/com/palantir/docker/compose/execution/DockerComposeRunOption.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.docker.compose.execution;
+
+import java.util.Arrays;
+import java.util.List;
+import org.immutables.value.Value;
+
+@Value.Immutable
+public abstract class DockerComposeRunOption {
+    @Value.Parameter
+    protected abstract String[] options();
+
+    public static DockerComposeRunOption options(String... options) {
+        return ImmutableDockerComposeRunOption.of(options);
+    }
+
+    public List<String> asList() {
+        return Arrays.asList(options());
+    }
+}

--- a/src/test/java/com/palantir/docker/compose/DockerCompositionIntegrationTest.java
+++ b/src/test/java/com/palantir/docker/compose/DockerCompositionIntegrationTest.java
@@ -28,6 +28,8 @@ import com.palantir.docker.compose.connection.Container;
 import com.palantir.docker.compose.connection.State;
 import com.palantir.docker.compose.connection.waiting.HealthCheck;
 import com.palantir.docker.compose.connection.waiting.SuccessOrFailure;
+import com.palantir.docker.compose.execution.DockerComposeRunArgument;
+import com.palantir.docker.compose.execution.DockerComposeRunOption;
 import java.io.IOException;
 import java.util.List;
 import java.util.function.Consumer;
@@ -145,4 +147,8 @@ public class DockerCompositionIntegrationTest {
         assertThat(docker.exec(options(), CONTAINERS.get(0), arguments("echo", "hello")), is("hello"));
     }
 
+    @Test
+    public void run_returns_output() throws Exception {
+        assertThat(docker.run(DockerComposeRunOption.options("--entrypoint", "echo"), CONTAINERS.get(0), DockerComposeRunArgument.arguments("hello")), is("hello"));
+    }
 }

--- a/src/test/java/com/palantir/docker/compose/execution/DockerComposeShould.java
+++ b/src/test/java/com/palantir/docker/compose/execution/DockerComposeShould.java
@@ -182,9 +182,16 @@ public class DockerComposeShould {
     }
 
     @Test
+    public void pass_concatenated_arguments_to_executor_on_docker_compose_run()
+            throws IOException, InterruptedException {
+        compose.run(DockerComposeRunOption.options("-d"), "container_1", DockerComposeRunArgument.arguments("ls"));
+        verify(executor, times(1)).execute("run", "-d", "container_1", "ls");
+    }
+
+    @Test
     public void return_the_output_from_the_executed_process_on_docker_compose_exec() throws Exception {
         String lsString = "-rw-r--r--  1 user  1318458867  11326 Mar  9 17:47 LICENSE\n"
-                             + "-rw-r--r--  1 user  1318458867  12570 May 12 14:51 README.md";
+                + "-rw-r--r--  1 user  1318458867  12570 May 12 14:51 README.md";
 
         String versionString = "docker-compose version 1.7.0rc1, build 1ad8866";
 
@@ -196,6 +203,20 @@ public class DockerComposeShould {
         DockerCompose processCompose = new DefaultDockerCompose(processExecutor, dockerMachine);
 
         assertThat(processCompose.exec(options(), "container_1", arguments("ls", "-l")), is(lsString));
+    }
+
+    @Test
+    public void return_the_output_from_the_executed_process_on_docker_compose_run() throws Exception {
+        String lsString = "-rw-r--r--  1 user  1318458867  11326 Mar  9 17:47 LICENSE\n"
+                + "-rw-r--r--  1 user  1318458867  12570 May 12 14:51 README.md";
+
+        DockerComposeExecutable processExecutor = mock(DockerComposeExecutable.class);
+
+        addProcessToExecutor(processExecutor, processWithOutput(lsString), "run", "-it", "container_1", "ls", "-l");
+
+        DockerCompose processCompose = new DefaultDockerCompose(processExecutor, dockerMachine);
+
+        assertThat(processCompose.run(DockerComposeRunOption.options("-it"), "container_1", DockerComposeRunArgument.arguments("ls", "-l")), is(lsString));
     }
 
     private void addProcessToExecutor(DockerComposeExecutable dockerComposeExecutable, Process process, String... commands) throws Exception {

--- a/src/test/java/com/palantir/docker/compose/execution/RetryingDockerComposeShould.java
+++ b/src/test/java/com/palantir/docker/compose/execution/RetryingDockerComposeShould.java
@@ -84,4 +84,11 @@ public class RetryingDockerComposeShould {
         verifyRetryerWasNotUsed();
         verify(dockerCompose).exec(options("-d"), CONTAINER_NAME, arguments("ls"));
     }
+
+    @Test
+    public void calls_run_on_the_underlying_docker_compose_and_not_invoke_retryer() throws IOException, InterruptedException {
+        retryingDockerCompose.run(DockerComposeRunOption.options("-d"), CONTAINER_NAME, DockerComposeRunArgument.arguments("ls"));
+        verifyRetryerWasNotUsed();
+        verify(dockerCompose).run(DockerComposeRunOption.options("-d"), CONTAINER_NAME, DockerComposeRunArgument.arguments("ls"));
+    }
 }


### PR DESCRIPTION
Add support for calling docker-compose run. This feature is needed so we can work around the CircleCI issue of not being able to use ```lxc-attach``` or ```docker exec``` on docker 1.10 and higher.

