### PR TITLE
Add method to kill a container

### DIFF
--- a/src/main/java/com/palantir/docker/compose/connection/Container.java
+++ b/src/main/java/com/palantir/docker/compose/connection/Container.java
@@ -89,6 +89,10 @@ public class Container {
         dockerComposeProcess.stop(this);
     }
 
+    public void kill() throws IOException, InterruptedException {
+        dockerComposeProcess.kill(this);
+    }
+
     public State state() throws IOException, InterruptedException {
         return dockerComposeProcess.state(containerName);
     }

--- a/src/main/java/com/palantir/docker/compose/execution/DefaultDockerCompose.java
+++ b/src/main/java/com/palantir/docker/compose/execution/DefaultDockerCompose.java
@@ -101,6 +101,11 @@ public class DefaultDockerCompose implements DockerCompose {
     }
 
     @Override
+    public void kill(Container container) throws IOException, InterruptedException {
+        command.execute(Command.throwingOnError(), "kill", container.getContainerName());
+    }
+
+    @Override
     public String exec(DockerComposeExecOption dockerComposeExecOption, String containerName,
             DockerComposeExecArgument dockerComposeExecArgument) throws IOException, InterruptedException {
         verifyDockerComposeVersionAtLeast(VERSION_1_7_0, "You need at least docker-compose 1.7 to run docker-compose exec");

--- a/src/main/java/com/palantir/docker/compose/execution/DelegatingDockerCompose.java
+++ b/src/main/java/com/palantir/docker/compose/execution/DelegatingDockerCompose.java
@@ -70,6 +70,11 @@ abstract class DelegatingDockerCompose implements DockerCompose {
     }
 
     @Override
+    public void kill(Container container) throws IOException, InterruptedException {
+        dockerCompose.kill(container);
+    }
+
+    @Override
     public String exec(DockerComposeExecOption dockerComposeExecOption, String containerName,
             DockerComposeExecArgument dockerComposeExecArgument) throws IOException, InterruptedException {
         return dockerCompose.exec(dockerComposeExecOption, containerName, dockerComposeExecArgument);

--- a/src/main/java/com/palantir/docker/compose/execution/DockerCompose.java
+++ b/src/main/java/com/palantir/docker/compose/execution/DockerCompose.java
@@ -31,6 +31,7 @@ public interface DockerCompose {
     void up(Container container) throws IOException, InterruptedException;
     void start(Container container) throws IOException, InterruptedException;
     void stop(Container container) throws IOException, InterruptedException;
+    void kill(Container container) throws IOException, InterruptedException;
     String exec(DockerComposeExecOption dockerComposeExecOption, String containerName, DockerComposeExecArgument dockerComposeExecArgument) throws IOException, InterruptedException;
     String run(DockerComposeRunOption dockerComposeRunOption, String containerName, DockerComposeRunArgument dockerComposeRunArgument) throws IOException, InterruptedException;
     ContainerNames ps() throws IOException, InterruptedException;

--- a/src/test/java/com/palantir/docker/compose/DockerCompositionIntegrationTest.java
+++ b/src/test/java/com/palantir/docker/compose/DockerCompositionIntegrationTest.java
@@ -141,6 +141,39 @@ public class DockerCompositionIntegrationTest {
         });
     }
 
+    @Test
+    public void can_kill_and_start_containers() {
+        forEachContainer(containerName -> {
+            try {
+                Container container = docker.containers().container(containerName);
+
+                container.kill();
+                assertThat(container.state(), is(State.Exit));
+
+                container.start();
+                assertThat(container.state(), is(State.Up));
+            } catch (IOException | InterruptedException e) {
+                propagate(e);
+            }
+        });
+    }
+
+    @Test
+    public void kill_can_be_run_on_killed_container() {
+        forEachContainer(containerName -> {
+            try {
+                Container container = docker.containers().container(containerName);
+
+                container.kill();
+                assertThat(container.state(), is(State.Exit));
+
+                container.kill();
+            } catch (IOException | InterruptedException e) {
+                propagate(e);
+            }
+        });
+    }
+
     @Ignore // This test will not run on Circle CI because it does not currently support docker-compose exec.
     @Test
     public void exec_returns_output() throws Exception {


### PR DESCRIPTION
Stop(Container) sends a SIGTERM followed by a SIGKILL to a container that allows time for graceful shutdown. We want to kill a node i.e. a container to simulate node dying. 

Your PR should contain a few sentences describing what problem your PR solves.

