### PR TITLE
Fix depluralize() compile warning

### DIFF
--- a/src/main/java/com/palantir/docker/compose/Depluralized.java
+++ b/src/main/java/com/palantir/docker/compose/Depluralized.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.docker.compose;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Target;
+import org.immutables.value.Value.Style;
+
+@Target({ElementType.PACKAGE, ElementType.TYPE})
+@Style(depluralize = true)
+@interface Depluralized {}

--- a/src/main/java/com/palantir/docker/compose/DockerComposeRule.java
+++ b/src/main/java/com/palantir/docker/compose/DockerComposeRule.java
@@ -40,7 +40,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 @Value.Immutable
-@Value.Style(depluralize = true)
+@Depluralized
 public abstract class DockerComposeRule extends ExternalResource {
     public static final Duration DEFAULT_TIMEOUT = Duration.standardMinutes(2);
     public static final int DEFAULT_RETRY_ATTEMPTS = 2;


### PR DESCRIPTION
This PR fixes a compile warning concerning `depluralize()`. It is the same issue that was addressed here: https://github.com/palantir/docker-compose-rule/commit/d929d35e936ae6915a2f3ff8924e87fba9a4d888
