### PR TITLE
Add string version of circleAwareLogDirectory.

### DIFF
--- a/src/main/java/com/palantir/docker/compose/logging/LogDirectory.java
+++ b/src/main/java/com/palantir/docker/compose/logging/LogDirectory.java
@@ -21,8 +21,12 @@ public class LogDirectory {
      * @param testClass the JUnit test class whose name will appear on the log folder
      */
     public static String circleAwareLogDirectory(Class<?> testClass) {
+        return circleAwareLogDirectory(testClass.getSimpleName());
+    }
+
+    public static String circleAwareLogDirectory(String logDirectoryName) {
         String artifactRoot = Optional.ofNullable(System.getenv("CIRCLE_ARTIFACTS")).orElse("build");
-        return artifactRoot + "/dockerLogs/" + testClass.getSimpleName();
+        return artifactRoot + "/dockerLogs/" + logDirectoryName;
     }
 
     /**

--- a/src/test/java/com/palantir/docker/compose/logging/LogDirectoryTest.java
+++ b/src/test/java/com/palantir/docker/compose/logging/LogDirectoryTest.java
@@ -37,5 +37,13 @@ public class LogDirectoryTest {
         assertThat(directory, is("/tmp/circle-artifacts.g4DjuuD/dockerLogs/SomeTestClass"));
     }
 
+    @Test
+    public void circleAwareLogDirectory_should_append_logDirectoryName_to_path() {
+        variablesRule.set("CIRCLE_ARTIFACTS", "/tmp/circle-artifacts.123456");
+
+        String directory = LogDirectory.circleAwareLogDirectory("some-path");
+        assertThat(directory, is("/tmp/circle-artifacts.123456/dockerLogs/some-path"));
+    }
+
     private static class SomeTestClass {}
 }


### PR DESCRIPTION
This solves the case when multiple classes have the same name, or the rule is part of a superclass