### PR TITLE
Switch to immutables strict builder

### DIFF
--- a/src/main/java/com/palantir/docker/compose/CustomImmutablesStyle.java
+++ b/src/main/java/com/palantir/docker/compose/CustomImmutablesStyle.java
@@ -20,5 +20,5 @@ import java.lang.annotation.Target;
 import org.immutables.value.Value.Style;
 
 @Target({ElementType.PACKAGE, ElementType.TYPE})
-@Style(depluralize = true)
-@interface Depluralized {}
+@Style(depluralize = true, strictBuilder = true)
+@interface CustomImmutablesStyle {}

--- a/src/main/java/com/palantir/docker/compose/DockerComposeRule.java
+++ b/src/main/java/com/palantir/docker/compose/DockerComposeRule.java
@@ -43,7 +43,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 @Value.Immutable
-@Depluralized
+@CustomImmutablesStyle
 public abstract class DockerComposeRule extends ExternalResource {
     public static final Duration DEFAULT_TIMEOUT = Duration.standardMinutes(2);
     public static final int DEFAULT_RETRY_ATTEMPTS = 2;
@@ -219,6 +219,10 @@ public abstract class DockerComposeRule extends ExternalResource {
         public Builder waitingForHostNetworkedPort(int port, HealthCheck<DockerPort> healthCheck, ReadableDuration timeout) {
             ClusterHealthCheck clusterHealthCheck = transformingHealthCheck(cluster -> new DockerPort(cluster.ip(), port, port), healthCheck);
             return addClusterWait(new ClusterWait(clusterHealthCheck, timeout));
+        }
+
+        public Builder clusterWaits(Iterable<? extends ClusterWait> elements) {
+            return addAllClusterWaits(elements);
         }
     }
 


### PR DESCRIPTION
This removes a few generated methods too, e.g, you can no longer initialise a builder `from` an existing instance.

fixes #118 

