### PR TITLE
Add a noOptions method to DockerComposeExecOption

### DIFF
--- a/src/main/java/com/palantir/docker/compose/execution/DockerComposeExecOption.java
+++ b/src/main/java/com/palantir/docker/compose/execution/DockerComposeExecOption.java
@@ -15,9 +15,9 @@
  */
 package com.palantir.docker.compose.execution;
 
+import com.google.common.collect.ImmutableList;
 import java.util.Arrays;
 import java.util.List;
-
 import org.immutables.value.Value;
 
 @Value.Immutable
@@ -27,5 +27,9 @@ public abstract class DockerComposeExecOption {
 
     public static DockerComposeExecOption options(String... options) {
         return ImmutableDockerComposeExecOption.of(Arrays.asList(options));
+    }
+
+    public static DockerComposeExecOption noOptions() {
+        return ImmutableDockerComposeExecOption.of(ImmutableList.of());
     }
 }

--- a/src/test/java/com/palantir/docker/compose/execution/DockerComposeExecOptionShould.java
+++ b/src/test/java/com/palantir/docker/compose/execution/DockerComposeExecOptionShould.java
@@ -1,0 +1,16 @@
+package com.palantir.docker.compose.execution;
+
+import static com.palantir.docker.compose.execution.DockerComposeExecOption.noOptions;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.collection.IsEmptyCollection.empty;
+
+import org.junit.Test;
+
+public class DockerComposeExecOptionShould {
+
+    @Test public void
+    be_constructable_with_no_args() {
+        DockerComposeExecOption option = noOptions();
+        assertThat(option.options(), empty());
+    }
+}

--- a/src/test/java/com/palantir/docker/compose/execution/DockerComposeExecOptionShould.java
+++ b/src/test/java/com/palantir/docker/compose/execution/DockerComposeExecOptionShould.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.palantir.docker.compose.execution;
 
 import static com.palantir.docker.compose.execution.DockerComposeExecOption.noOptions;


### PR DESCRIPTION
Fixed up checkstyle problems from #114.

> Non-breaking change to fix an overloading bug.
> 
> Fixes #113.
> 
> 34d64fe made the protected instance method options() public, which
> makes it clash with the public static method options(String...) in the
> frequent case you don't want to pass any options.
> 
> This PR adds a noOptions() method which avoids this kind of bad
> behaviour.
> 
> I did this because everything else would break at least one person. More
> generally, it's probably advisable to try to name static methods
> differently to instance methods, or you open yourself up to these
> overloading based bugs.