### PR TITLE
LocalBuilder: Allow additionalEnvironment to override systemEnvironment

### DIFF
--- a/src/main/java/com/palantir/docker/compose/connection/DockerMachine.java
+++ b/src/main/java/com/palantir/docker/compose/connection/DockerMachine.java
@@ -22,7 +22,6 @@ import static com.palantir.docker.compose.configuration.EnvironmentVariables.DOC
 import static com.palantir.docker.compose.configuration.EnvironmentVariables.DOCKER_TLS_VERIFY;
 
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Maps;
 import com.palantir.docker.compose.configuration.AdditionalEnvironmentValidator;
 import com.palantir.docker.compose.configuration.DockerType;
 import com.palantir.docker.compose.configuration.RemoteHostIpResolver;
@@ -101,15 +100,12 @@ public class DockerMachine implements DockerConfiguration {
         public DockerMachine build() {
             dockerType.validateEnvironmentVariables(systemEnvironment);
             AdditionalEnvironmentValidator.validate(additionalEnvironment);
-            Map<String, String> combinedEnvironment = Maps.newHashMap();
+            Map<String, String> combinedEnvironment = newHashMap();
             combinedEnvironment.putAll(systemEnvironment);
             combinedEnvironment.putAll(additionalEnvironment);
-            Map<String, String> environment = ImmutableMap.<String, String>builder()
-                    .putAll(combinedEnvironment)
-                    .build();
 
             String dockerHost = systemEnvironment.getOrDefault(DOCKER_HOST, "");
-            return new DockerMachine(dockerType.resolveIp(dockerHost), environment);
+            return new DockerMachine(dockerType.resolveIp(dockerHost), ImmutableMap.copyOf(combinedEnvironment));
         }
     }
 

--- a/src/main/java/com/palantir/docker/compose/connection/DockerMachine.java
+++ b/src/main/java/com/palantir/docker/compose/connection/DockerMachine.java
@@ -22,6 +22,7 @@ import static com.palantir.docker.compose.configuration.EnvironmentVariables.DOC
 import static com.palantir.docker.compose.configuration.EnvironmentVariables.DOCKER_TLS_VERIFY;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
 import com.palantir.docker.compose.configuration.AdditionalEnvironmentValidator;
 import com.palantir.docker.compose.configuration.DockerType;
 import com.palantir.docker.compose.configuration.RemoteHostIpResolver;
@@ -100,9 +101,11 @@ public class DockerMachine implements DockerConfiguration {
         public DockerMachine build() {
             dockerType.validateEnvironmentVariables(systemEnvironment);
             AdditionalEnvironmentValidator.validate(additionalEnvironment);
+            Map<String, String> combinedEnvironment = Maps.newHashMap();
+            combinedEnvironment.putAll(systemEnvironment);
+            combinedEnvironment.putAll(additionalEnvironment);
             Map<String, String> environment = ImmutableMap.<String, String>builder()
-                    .putAll(systemEnvironment)
-                    .putAll(additionalEnvironment)
+                    .putAll(combinedEnvironment)
                     .build();
 
             String dockerHost = systemEnvironment.getOrDefault(DOCKER_HOST, "");

--- a/src/test/java/com/palantir/docker/compose/connection/LocalBuilderShould.java
+++ b/src/test/java/com/palantir/docker/compose/connection/LocalBuilderShould.java
@@ -112,6 +112,22 @@ public class LocalBuilderShould {
     }
 
     @Test
+    public void override_system_environment_with_additional_environment() throws Exception {
+        Map<String, String> systemEnv = ImmutableMap.<String, String>builder()
+                .put("ENV_1", "VAL_1")
+                .build();
+        Map<String, String> overrideEnv = ImmutableMap.<String, String>builder()
+                .put("ENV_1", "DIFFERENT_VALUE")
+                .build();
+        DockerMachine localMachine = new LocalBuilder(DAEMON, systemEnv)
+                .withEnvironment(overrideEnv)
+                .build();
+
+        assertThat(localMachine, not(containsEnvironment(systemEnv)));
+        assertThat(localMachine, containsEnvironment(overrideEnv));
+    }
+
+    @Test
     public void have_invalid_variables_daemon() throws Exception {
         Map<String, String> invalidDockerVariables = ImmutableMap.<String, String>builder()
                 .put(DOCKER_HOST, "tcp://192.168.99.100:2376")


### PR DESCRIPTION
The docker reserved variables (DOCKER_TLS_VERIFY, DOCKER_HOST,
DOCKER_CERT_PATH) are still not allowed in additionalEnvironment.
But the user can now override their own environment variables
programatically. (See AtlasDB PR 1237).

Fixes #131.