### PR TITLE
Cleanup warnings

### DIFF
--- a/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/configuration/RemoteEnvironmentValidator.java
+++ b/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/configuration/RemoteEnvironmentValidator.java
@@ -53,7 +53,7 @@ public class RemoteEnvironmentValidator implements EnvironmentValidator {
         Preconditions.checkState(missingVariables.isEmpty(), errorMessage);
     }
 
-    private Collection<String> getMissingEnvVariables(Map<String, String> dockerEnvironment) {
+    private static Collection<String> getMissingEnvVariables(Map<String, String> dockerEnvironment) {
         Collection<String> requiredVariables = Sets.union(newHashSet(DOCKER_HOST),
                 secureVariablesRequired(dockerEnvironment));
         return requiredVariables.stream()
@@ -61,11 +61,11 @@ public class RemoteEnvironmentValidator implements EnvironmentValidator {
                                 .collect(Collectors.toSet());
     }
 
-    private Set<String> secureVariablesRequired(Map<String, String> dockerEnvironment) {
+    private static Set<String> secureVariablesRequired(Map<String, String> dockerEnvironment) {
         return certVerificationEnabled(dockerEnvironment) ? SECURE_VARIABLES : newHashSet();
     }
 
-    private boolean certVerificationEnabled(Map<String, String> dockerEnvironment) {
+    private static boolean certVerificationEnabled(Map<String, String> dockerEnvironment) {
         return dockerEnvironment.containsKey(DOCKER_TLS_VERIFY);
     }
 

--- a/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/connection/waiting/ClusterWait.java
+++ b/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/connection/waiting/ClusterWait.java
@@ -60,7 +60,7 @@ public class ClusterWait {
         };
     }
 
-    private String serviceDidNotStartupExceptionMessage(
+    private static String serviceDidNotStartupExceptionMessage(
             AtomicReference<Optional<SuccessOrFailure>> lastSuccessOrFailure) {
         String healthcheckFailureMessage = lastSuccessOrFailure.get()
                 .flatMap(SuccessOrFailure::toOptionalFailureMessage)

--- a/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/execution/AggressiveShutdownStrategy.java
+++ b/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/execution/AggressiveShutdownStrategy.java
@@ -39,7 +39,7 @@ public class AggressiveShutdownStrategy implements ShutdownStrategy {
                 + "see https://circleci.com/docs/docker-btrfs-error/ for more info.");
     }
 
-    private boolean removeContainersCatchingErrors(Docker docker, List<ContainerName> runningContainers) throws IOException, InterruptedException {
+    private static boolean removeContainersCatchingErrors(Docker docker, List<ContainerName> runningContainers) throws IOException, InterruptedException {
         try {
             removeContainers(docker, runningContainers);
             return true;
@@ -48,7 +48,7 @@ public class AggressiveShutdownStrategy implements ShutdownStrategy {
         }
     }
 
-    private void removeContainers(Docker docker, List<ContainerName> running) throws IOException, InterruptedException {
+    private static void removeContainers(Docker docker, List<ContainerName> running) throws IOException, InterruptedException {
         List<String> rawContainerNames = running.stream()
                 .map(ContainerName::rawName)
                 .collect(toList());

--- a/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/execution/AggressiveShutdownWithNetworkCleanupStrategy.java
+++ b/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/execution/AggressiveShutdownWithNetworkCleanupStrategy.java
@@ -29,7 +29,7 @@ public class AggressiveShutdownWithNetworkCleanupStrategy implements ShutdownStr
         removeNetworks(dockerCompose);
     }
 
-    private void removeContainersCatchingErrors(Docker docker, List<ContainerName> runningContainers) throws IOException, InterruptedException {
+    private static void removeContainersCatchingErrors(Docker docker, List<ContainerName> runningContainers) throws IOException, InterruptedException {
         try {
             removeContainers(docker, runningContainers);
         } catch (DockerExecutionException exception) {
@@ -37,7 +37,7 @@ public class AggressiveShutdownWithNetworkCleanupStrategy implements ShutdownStr
         }
     }
 
-    private void removeContainers(Docker docker, List<ContainerName> running) throws IOException, InterruptedException {
+    private static void removeContainers(Docker docker, List<ContainerName> running) throws IOException, InterruptedException {
         List<String> rawContainerNames = running.stream()
                 .map(ContainerName::rawName)
                 .collect(toList());
@@ -46,7 +46,7 @@ public class AggressiveShutdownWithNetworkCleanupStrategy implements ShutdownStr
         log.debug("Finished shutdown");
     }
 
-    private void removeNetworks(DockerCompose dockerCompose) throws IOException, InterruptedException {
+    private static void removeNetworks(DockerCompose dockerCompose) throws IOException, InterruptedException {
         dockerCompose.down();
     }
 }

--- a/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/execution/Command.java
+++ b/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/execution/Command.java
@@ -87,7 +87,7 @@ public class Command {
                 .collect(joining(System.lineSeparator()));
     }
 
-    private String waitForResultFrom(Future<String> outputProcessing) {
+    private static String waitForResultFrom(Future<String> outputProcessing) {
         try {
             return outputProcessing.get(HOURS_TO_WAIT_FOR_STD_OUT_TO_CLOSE, TimeUnit.HOURS);
         } catch (InterruptedException | ExecutionException | TimeoutException e) {
@@ -95,7 +95,7 @@ public class Command {
         }
     }
 
-    private BufferedReader asReader(InputStream inputStream) {
+    private static BufferedReader asReader(InputStream inputStream) {
         return new BufferedReader(new InputStreamReader(inputStream, UTF_8));
     }
 }

--- a/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/execution/DefaultDockerCompose.java
+++ b/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/execution/DefaultDockerCompose.java
@@ -133,7 +133,7 @@ public class DefaultDockerCompose implements DockerCompose {
         return DockerComposeVersion.parseFromDockerComposeVersion(versionOutput);
     }
 
-    private String[] constructFullDockerComposeExecArguments(DockerComposeExecOption dockerComposeExecOption,
+    private static String[] constructFullDockerComposeExecArguments(DockerComposeExecOption dockerComposeExecOption,
             String containerName, DockerComposeExecArgument dockerComposeExecArgument) {
         ImmutableList<String> fullArgs = new ImmutableList.Builder<String>().add("exec")
                                                                             .addAll(dockerComposeExecOption.options())
@@ -143,7 +143,7 @@ public class DefaultDockerCompose implements DockerCompose {
         return fullArgs.toArray(new String[fullArgs.size()]);
     }
 
-    private String[] constructFullDockerComposeRunArguments(DockerComposeRunOption dockerComposeRunOption,
+    private static String[] constructFullDockerComposeRunArguments(DockerComposeRunOption dockerComposeRunOption,
             String containerName, DockerComposeRunArgument dockerComposeRunArgument) {
         ImmutableList<String> fullArgs = new ImmutableList.Builder<String>().add("run")
                 .addAll(dockerComposeRunOption.options())
@@ -204,7 +204,7 @@ public class DefaultDockerCompose implements DockerCompose {
         return State.parseFromDockerComposePs(psOutput(service));
     }
 
-    private ErrorHandler swallowingDownCommandDoesNotExist() {
+    private static ErrorHandler swallowingDownCommandDoesNotExist() {
         return (exitCode, output, commandName, commands) -> {
             if (downCommandWasPresent(output)) {
                 Command.throwingOnError().handle(exitCode, output, commandName, commands);
@@ -216,7 +216,7 @@ public class DefaultDockerCompose implements DockerCompose {
         };
     }
 
-    private boolean downCommandWasPresent(String output) {
+    private static boolean downCommandWasPresent(String output) {
         return !output.contains("No such command");
     }
 

--- a/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/execution/SkipShutdownStrategy.java
+++ b/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/execution/SkipShutdownStrategy.java
@@ -5,7 +5,6 @@
 package com.palantir.docker.compose.execution;
 
 import com.palantir.docker.compose.configuration.ShutdownStrategy;
-import java.io.IOException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -14,7 +13,7 @@ public class SkipShutdownStrategy implements ShutdownStrategy {
     private static final Logger log = LoggerFactory.getLogger(SkipShutdownStrategy.class);
 
     @Override
-    public void shutdown(DockerCompose dockerCompose, Docker docker) throws IOException, InterruptedException {
+    public void shutdown(DockerCompose dockerCompose, Docker docker) {
         log.warn("\n"
                 + "******************************************************************************************\n"
                 + "* docker-compose-rule has been configured to skip docker-compose shutdown:               *\n"

--- a/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/logging/DoNothingLogCollector.java
+++ b/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/logging/DoNothingLogCollector.java
@@ -16,17 +16,16 @@
 package com.palantir.docker.compose.logging;
 
 import com.palantir.docker.compose.execution.DockerCompose;
-import java.io.IOException;
 
 public class DoNothingLogCollector implements LogCollector {
 
     @Override
-    public void startCollecting(DockerCompose dockerCompose) throws IOException, InterruptedException {
+    public void startCollecting(DockerCompose dockerCompose) {
 
     }
 
     @Override
-    public void stopCollecting() throws InterruptedException {
+    public void stopCollecting() {
 
     }
 

--- a/docker-compose-rule-core/src/test/java/com/palantir/docker/compose/configuration/AdditionalEnvironmentValidatorShould.java
+++ b/docker-compose-rule-core/src/test/java/com/palantir/docker/compose/configuration/AdditionalEnvironmentValidatorShould.java
@@ -30,7 +30,7 @@ public class AdditionalEnvironmentValidatorShould {
     public ExpectedException exception = ExpectedException.none();
 
     @Test
-    public void throw_exception_when_additional_environment_variables_contain_docker_variables() throws Exception {
+    public void throw_exception_when_additional_environment_variables_contain_docker_variables() {
         Map<String, String> variables = ImmutableMap.<String, String>builder().put("DOCKER_HOST", "tcp://some-host:2376")
                                                                               .put("SOME_VARIABLE", "Some Value")
                                                                               .build();
@@ -42,7 +42,7 @@ public class AdditionalEnvironmentValidatorShould {
     }
 
     @Test
-    public void validate_arbitrary_environment_variables() throws Exception {
+    public void validate_arbitrary_environment_variables() {
         Map<String, String> variables = ImmutableMap.<String, String>builder().put("SOME_VARIABLE", "Some Value")
                                                                               .build();
 

--- a/docker-compose-rule-core/src/test/java/com/palantir/docker/compose/configuration/DaemonEnvironmentValidatorShould.java
+++ b/docker-compose-rule-core/src/test/java/com/palantir/docker/compose/configuration/DaemonEnvironmentValidatorShould.java
@@ -31,7 +31,7 @@ public class DaemonEnvironmentValidatorShould {
     public ExpectedException exception = ExpectedException.none();
 
     @Test
-    public void validate_successfully_when_docker_environment_does_not_contain_docker_variables() throws Exception {
+    public void validate_successfully_when_docker_environment_does_not_contain_docker_variables() {
         Map<String, String> variables = ImmutableMap.<String, String>builder()
                                                     .put("SOME_VARIABLE", "SOME_VALUE")
                                                     .put("ANOTHER_VARIABLE", "ANOTHER_VALUE")
@@ -41,7 +41,7 @@ public class DaemonEnvironmentValidatorShould {
     }
 
     @Test
-    public void throw_exception_when_docker_environment_contains_illegal_docker_variables() throws Exception {
+    public void throw_exception_when_docker_environment_contains_illegal_docker_variables() {
         Map<String, String> variables = ImmutableMap.<String, String>builder()
                 .put(DOCKER_HOST, "tcp://192.168.99.100:2376")
                 .put(DOCKER_TLS_VERIFY, "1")

--- a/docker-compose-rule-core/src/test/java/com/palantir/docker/compose/configuration/DaemonHostIpResolverShould.java
+++ b/docker-compose-rule-core/src/test/java/com/palantir/docker/compose/configuration/DaemonHostIpResolverShould.java
@@ -24,17 +24,17 @@ import org.junit.Test;
 public class DaemonHostIpResolverShould {
 
     @Test
-    public void return_local_host_with_null() throws Exception {
+    public void return_local_host_with_null() {
         assertThat(new DaemonHostIpResolver().resolveIp(null), is(LOCALHOST));
     }
 
     @Test
-    public void return_local_host_with_blank() throws Exception {
+    public void return_local_host_with_blank() {
         assertThat(new DaemonHostIpResolver().resolveIp(""), is(LOCALHOST));
     }
 
     @Test
-    public void return_local_host_with_arbitrary() throws Exception {
+    public void return_local_host_with_arbitrary() {
         assertThat(new DaemonHostIpResolver().resolveIp("arbitrary"), is(LOCALHOST));
     }
 

--- a/docker-compose-rule-core/src/test/java/com/palantir/docker/compose/configuration/DockerComposeFilesShould.java
+++ b/docker-compose-rule-core/src/test/java/com/palantir/docker/compose/configuration/DockerComposeFilesShould.java
@@ -35,14 +35,14 @@ public class DockerComposeFilesShould {
     public final ExpectedException exception = ExpectedException.none();
 
     @Test
-    public void throw_exception_when_compose_file_is_not_specified() throws Exception {
+    public void throw_exception_when_compose_file_is_not_specified() {
         exception.expect(IllegalArgumentException.class);
         exception.expectMessage("A docker compose file must be specified.");
         DockerComposeFiles.from();
     }
 
     @Test
-    public void throw_exception_when_compose_file_does_not_exist() throws Exception {
+    public void throw_exception_when_compose_file_does_not_exist() {
         exception.expect(IllegalStateException.class);
         exception.expectMessage("The following docker-compose files:");
         exception.expectMessage("does-not-exist.yaml");

--- a/docker-compose-rule-core/src/test/java/com/palantir/docker/compose/configuration/MockDockerEnvironment.java
+++ b/docker-compose-rule-core/src/test/java/com/palantir/docker/compose/configuration/MockDockerEnvironment.java
@@ -74,7 +74,7 @@ public class MockDockerEnvironment {
         when(dockerComposeProcess.ports(service)).thenReturn(new Ports(ports));
     }
 
-    private DockerPort dockerPortSpy(String ip, int externalPortNumber, int internalPortNumber) {
+    private static DockerPort dockerPortSpy(String ip, int externalPortNumber, int internalPortNumber) {
         DockerPort port = new DockerPort(ip, externalPortNumber, internalPortNumber);
         return spy(port);
     }

--- a/docker-compose-rule-core/src/test/java/com/palantir/docker/compose/configuration/RemoteEnvironmentValidatorShould.java
+++ b/docker-compose-rule-core/src/test/java/com/palantir/docker/compose/configuration/RemoteEnvironmentValidatorShould.java
@@ -31,7 +31,7 @@ public class RemoteEnvironmentValidatorShould {
     public ExpectedException exception = ExpectedException.none();
 
     @Test
-    public void throw_exception_if_docker_host_is_not_set() throws Exception {
+    public void throw_exception_if_docker_host_is_not_set() {
         Map<String, String> variables = ImmutableMap.<String, String>builder()
                                                     .put("SOME_VARIABLE", "SOME_VALUE")
                                                     .build();
@@ -43,7 +43,7 @@ public class RemoteEnvironmentValidatorShould {
     }
 
     @Test
-    public void throw_exception_if_docker_cert_path_is_missing_and_tls_is_on() throws Exception {
+    public void throw_exception_if_docker_cert_path_is_missing_and_tls_is_on() {
         Map<String, String> variables = ImmutableMap.<String, String>builder()
                 .put(DOCKER_HOST, "tcp://192.168.99.100:2376")
                 .put(DOCKER_TLS_VERIFY, "1")
@@ -56,7 +56,7 @@ public class RemoteEnvironmentValidatorShould {
     }
 
     @Test
-    public void validate_environment_with_all_valid_variables_set_without_tls() throws Exception {
+    public void validate_environment_with_all_valid_variables_set_without_tls() {
         Map<String, String> variables = ImmutableMap.<String, String>builder()
                                                     .put(DOCKER_HOST, "tcp://192.168.99.100:2376")
                                                     .put("SOME_VARIABLE", "SOME_VALUE")
@@ -66,7 +66,7 @@ public class RemoteEnvironmentValidatorShould {
     }
 
     @Test
-    public void validate_environment_with_all_valid_variables_set_with_tls() throws Exception {
+    public void validate_environment_with_all_valid_variables_set_with_tls() {
         Map<String, String> variables = ImmutableMap.<String, String>builder()
                 .put(DOCKER_HOST, "tcp://192.168.99.100:2376")
                 .put(DOCKER_TLS_VERIFY, "1")

--- a/docker-compose-rule-core/src/test/java/com/palantir/docker/compose/configuration/RemoteHostIpResolverShould.java
+++ b/docker-compose-rule-core/src/test/java/com/palantir/docker/compose/configuration/RemoteHostIpResolverShould.java
@@ -32,27 +32,27 @@ public class RemoteHostIpResolverShould {
     public ExpectedException exception = ExpectedException.none();
 
     @Test
-    public void result_in_error_blank_when_resolving_invalid_docker_host() throws Exception {
+    public void result_in_error_blank_when_resolving_invalid_docker_host() {
         exception.expect(IllegalArgumentException.class);
         exception.expectMessage("DOCKER_HOST cannot be blank/null");
         new RemoteHostIpResolver().resolveIp("");
     }
 
     @Test
-    public void result_in_error_null_when_resolving_invalid_docker_host() throws Exception {
+    public void result_in_error_null_when_resolving_invalid_docker_host() {
         exception.expect(IllegalArgumentException.class);
         exception.expectMessage("DOCKER_HOST cannot be blank/null");
         new RemoteHostIpResolver().resolveIp(null);
     }
 
     @Test
-    public void resolve_docker_host_with_port() throws Exception {
+    public void resolve_docker_host_with_port() {
         String dockerHost = String.format("%s%s:%d", TCP_PROTOCOL, IP, PORT);
         assertThat(new RemoteHostIpResolver().resolveIp(dockerHost), Matchers.is(IP));
     }
 
     @Test
-    public void resolve_docker_host_without_port() throws Exception {
+    public void resolve_docker_host_without_port() {
         String dockerHost = String.format("%s%s", TCP_PROTOCOL, IP);
         assertThat(new RemoteHostIpResolver().resolveIp(dockerHost), Matchers.is(IP));
     }

--- a/docker-compose-rule-core/src/test/java/com/palantir/docker/compose/connection/LocalBuilderShould.java
+++ b/docker-compose-rule-core/src/test/java/com/palantir/docker/compose/connection/LocalBuilderShould.java
@@ -40,7 +40,7 @@ public class LocalBuilderShould {
     public ExpectedException exception = ExpectedException.none();
 
     @Test
-    public void override_previous_environment_when_additional_environment_set_twice_daemon() throws Exception {
+    public void override_previous_environment_when_additional_environment_set_twice_daemon() {
         Map<String, String> environment1 = ImmutableMap.of("ENV_1", "VAL_1");
         Map<String, String> environment2 = ImmutableMap.of("ENV_2", "VAL_2");
         DockerMachine localMachine = new LocalBuilder(DAEMON, newHashMap()).withEnvironment(environment1)
@@ -51,7 +51,7 @@ public class LocalBuilderShould {
     }
 
     @Test
-    public void be_union_of_additional_environment_and_individual_environment_when_both_set_daemon() throws Exception {
+    public void be_union_of_additional_environment_and_individual_environment_when_both_set_daemon() {
         Map<String, String> environment = ImmutableMap.<String, String>builder()
                                                        .put("ENV_1", "VAL_1")
                                                        .put("ENV_2", "VAL_2")
@@ -64,7 +64,7 @@ public class LocalBuilderShould {
     }
 
     @Test
-    public void override_previous_environment_with_additional_environment_set_twice_remote() throws Exception {
+    public void override_previous_environment_with_additional_environment_set_twice_remote() {
         Map<String, String> dockerVariables = ImmutableMap.<String, String>builder()
                 .put(DOCKER_HOST, "tcp://192.168.99.100:2376")
                 .build();
@@ -78,7 +78,7 @@ public class LocalBuilderShould {
     }
 
     @Test
-    public void be_union_of_additional_environment_and_individual_environment_when_both_set_remote() throws Exception {
+    public void be_union_of_additional_environment_and_individual_environment_when_both_set_remote() {
         Map<String, String> dockerVariables = ImmutableMap.<String, String>builder()
                 .put(DOCKER_HOST, "tcp://192.168.99.100:2376")
                 .build();
@@ -94,7 +94,7 @@ public class LocalBuilderShould {
     }
 
     @Test
-    public void get_variable_overriden_with_additional_environment() throws Exception {
+    public void get_variable_overriden_with_additional_environment() {
         Map<String, String> environment = ImmutableMap.<String, String>builder()
                 .put("ENV_1", "VAL_1")
                 .put("ENV_2", "VAL_2")
@@ -112,7 +112,7 @@ public class LocalBuilderShould {
     }
 
     @Test
-    public void override_system_environment_with_additional_environment() throws Exception {
+    public void override_system_environment_with_additional_environment() {
         Map<String, String> systemEnv = ImmutableMap.<String, String>builder()
                 .put("ENV_1", "VAL_1")
                 .build();
@@ -128,7 +128,7 @@ public class LocalBuilderShould {
     }
 
     @Test
-    public void have_invalid_variables_daemon() throws Exception {
+    public void have_invalid_variables_daemon() {
         Map<String, String> invalidDockerVariables = ImmutableMap.<String, String>builder()
                 .put(DOCKER_HOST, "tcp://192.168.99.100:2376")
                 .put(DOCKER_TLS_VERIFY, "1")
@@ -146,7 +146,7 @@ public class LocalBuilderShould {
     }
 
     @Test
-    public void have_invalid_additional_variables_daemon() throws Exception {
+    public void have_invalid_additional_variables_daemon() {
         exception.expect(IllegalStateException.class);
         exception.expectMessage("The following variables");
         exception.expectMessage(DOCKER_HOST);
@@ -157,7 +157,7 @@ public class LocalBuilderShould {
     }
 
     @Test
-    public void have_invalid_additional_variables_remote() throws Exception {
+    public void have_invalid_additional_variables_remote() {
         Map<String, String> dockerVariables = ImmutableMap.<String, String>builder()
                                                           .put(DOCKER_HOST, "tcp://192.168.99.100:2376")
                                                           .put(DOCKER_TLS_VERIFY, "1")
@@ -174,13 +174,13 @@ public class LocalBuilderShould {
     }
 
     @Test
-    public void return_localhost_as_ip_daemon() throws Exception {
+    public void return_localhost_as_ip_daemon() {
         DockerMachine localMachine = new LocalBuilder(DAEMON, newHashMap()).build();
         assertThat(localMachine.getIp(), is(LOCALHOST));
     }
 
     @Test
-    public void return_docker_host_as_ip_remote() throws Exception {
+    public void return_docker_host_as_ip_remote() {
         Map<String, String> dockerVariables = ImmutableMap.<String, String>builder()
                 .put(DOCKER_HOST, "tcp://192.168.99.100:2376")
                 .put(DOCKER_TLS_VERIFY, "1")
@@ -192,7 +192,7 @@ public class LocalBuilderShould {
     }
 
     @Test
-    public void have_missing_docker_host_remote() throws Exception {
+    public void have_missing_docker_host_remote() {
         exception.expect(IllegalStateException.class);
         exception.expectMessage("Missing required environment variables: ");
         exception.expectMessage(DOCKER_HOST);
@@ -200,7 +200,7 @@ public class LocalBuilderShould {
     }
 
     @Test
-    public void build_without_tls_remote() throws Exception {
+    public void build_without_tls_remote() {
         Map<String, String> dockerVariables = ImmutableMap.<String, String>builder()
                                                           .put(DOCKER_HOST, "tcp://192.168.99.100:2376")
                                                           .build();
@@ -210,7 +210,7 @@ public class LocalBuilderShould {
     }
 
     @Test
-    public void have_missing_cert_path_remote() throws Exception {
+    public void have_missing_cert_path_remote() {
         Map<String, String> dockerVariables = ImmutableMap.<String, String>builder()
                 .put(DOCKER_HOST, "tcp://192.168.99.100:2376")
                 .put(DOCKER_TLS_VERIFY, "1")
@@ -223,7 +223,7 @@ public class LocalBuilderShould {
     }
 
     @Test
-    public void build_with_tls_remote() throws Exception {
+    public void build_with_tls_remote() {
         Map<String, String> dockerVariables = ImmutableMap.<String, String>builder()
                 .put(DOCKER_HOST, "tcp://192.168.99.100:2376")
                 .put(DOCKER_TLS_VERIFY, "1")

--- a/docker-compose-rule-core/src/test/java/com/palantir/docker/compose/connection/PortsShould.java
+++ b/docker-compose-rule-core/src/test/java/com/palantir/docker/compose/connection/PortsShould.java
@@ -20,7 +20,6 @@ import static java.util.Collections.emptyList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 
-import java.io.IOException;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -32,7 +31,7 @@ public class PortsShould {
     public ExpectedException exception = ExpectedException.none();
 
     @Test
-    public void result_in_no_ports_when_there_are_no_ports_in_ps_output() throws IOException, InterruptedException {
+    public void result_in_no_ports_when_there_are_no_ports_in_ps_output() {
         String psOutput = "------";
         Ports ports = Ports.parseFromDockerComposePs(psOutput, null);
         Ports expected = new Ports(emptyList());
@@ -40,7 +39,7 @@ public class PortsShould {
     }
 
     @Test
-    public void result_in_single_port_when_there_is_single_tcp_port_mapping() throws IOException, InterruptedException {
+    public void result_in_single_port_when_there_is_single_tcp_port_mapping() {
         String psOutput = "0.0.0.0:5432->5432/tcp";
         Ports ports = Ports.parseFromDockerComposePs(psOutput, LOCALHOST_IP);
         Ports expected = new Ports(newArrayList(new DockerPort(LOCALHOST_IP, 5432, 5432)));
@@ -49,8 +48,7 @@ public class PortsShould {
 
     @Test
     public void
-            result_in_single_port_with_ip_other_than_localhost_when_there_is_single_tcp_port_mapping()
-            throws IOException, InterruptedException {
+            result_in_single_port_with_ip_other_than_localhost_when_there_is_single_tcp_port_mapping() {
         String psOutput = "10.0.1.2:1234->2345/tcp";
         Ports ports = Ports.parseFromDockerComposePs(psOutput, LOCALHOST_IP);
         Ports expected = new Ports(newArrayList(new DockerPort("10.0.1.2", 1234, 2345)));
@@ -58,7 +56,7 @@ public class PortsShould {
     }
 
     @Test
-    public void result_in_two_ports_when_there_are_two_tcp_port_mappings() throws IOException, InterruptedException {
+    public void result_in_two_ports_when_there_are_two_tcp_port_mappings() {
         String psOutput = "0.0.0.0:5432->5432/tcp, 0.0.0.0:5433->5432/tcp";
         Ports ports = Ports.parseFromDockerComposePs(psOutput, LOCALHOST_IP);
         Ports expected = new Ports(newArrayList(new DockerPort(LOCALHOST_IP, 5432, 5432),
@@ -67,7 +65,7 @@ public class PortsShould {
     }
 
     @Test
-    public void result_in_no_ports_when_there_is_a_non_mapped_exposed_port() throws IOException, InterruptedException {
+    public void result_in_no_ports_when_there_is_a_non_mapped_exposed_port() {
         String psOutput = "5432/tcp";
         Ports ports = Ports.parseFromDockerComposePs(psOutput, LOCALHOST_IP);
         Ports expected = new Ports(emptyList());
@@ -75,7 +73,7 @@ public class PortsShould {
     }
 
     @Test
-    public void parse_actual_docker_compose_output() throws IOException, InterruptedException {
+    public void parse_actual_docker_compose_output() {
         String psOutput =
                   "       Name                      Command               State                                         Ports                                        \n"
                 + "-------------------------------------------------------------------------------------------------------------------------------------------------\n"
@@ -87,8 +85,7 @@ public class PortsShould {
     }
 
     @Test
-    public void throw_illegal_state_exception_when_no_running_container_found_for_service()
-            throws IOException, InterruptedException {
+    public void throw_illegal_state_exception_when_no_running_container_found_for_service() {
         exception.expect(IllegalArgumentException.class);
         exception.expectMessage("No container found");
         Ports.parseFromDockerComposePs("", "");

--- a/docker-compose-rule-core/src/test/java/com/palantir/docker/compose/connection/RemoteBuilderShould.java
+++ b/docker-compose-rule-core/src/test/java/com/palantir/docker/compose/connection/RemoteBuilderShould.java
@@ -32,7 +32,7 @@ public class RemoteBuilderShould {
     public ExpectedException exception = ExpectedException.none();
 
     @Test
-    public void throw_exception_when_building_a_docker_machine_without_a_host() throws Exception {
+    public void throw_exception_when_building_a_docker_machine_without_a_host() {
         exception.expect(IllegalStateException.class);
         exception.expectMessage("Missing required environment variables");
         exception.expectMessage("DOCKER_HOST");
@@ -42,7 +42,7 @@ public class RemoteBuilderShould {
     }
 
     @Test
-    public void have_no_tls_environment_variables_when_a_docker_machine_is_built_without_tls() throws Exception {
+    public void have_no_tls_environment_variables_when_a_docker_machine_is_built_without_tls() {
         DockerMachine dockerMachine = DockerMachine.remoteMachine()
                                                    .host("tcp://192.168.99.100")
                                                    .withoutTLS()
@@ -56,7 +56,7 @@ public class RemoteBuilderShould {
     }
 
     @Test
-    public void have_tls_environment_variables_set_when_a_docker_machine_is_built_with_tls() throws Exception {
+    public void have_tls_environment_variables_set_when_a_docker_machine_is_built_with_tls() {
         DockerMachine dockerMachine = DockerMachine.remoteMachine()
                                                    .host("tcp://192.168.99.100")
                                                    .withTLS("/path/to/certs")
@@ -70,7 +70,7 @@ public class RemoteBuilderShould {
     }
 
     @Test
-    public void build_a_docker_machine_with_additional_environment_variables() throws Exception {
+    public void build_a_docker_machine_with_additional_environment_variables() {
         DockerMachine dockerMachine = DockerMachine.remoteMachine()
                                                    .host("tcp://192.168.99.100")
                                                    .withoutTLS()

--- a/docker-compose-rule-core/src/test/java/com/palantir/docker/compose/connection/RemoteBuilderShould.java
+++ b/docker-compose-rule-core/src/test/java/com/palantir/docker/compose/connection/RemoteBuilderShould.java
@@ -84,7 +84,7 @@ public class RemoteBuilderShould {
         validateEnvironmentConfiguredDirectly(dockerMachine, expected);
     }
 
-    private void validateEnvironmentConfiguredDirectly(DockerMachine dockerMachine, Map<String, String> expectedEnvironment) {
+    private static void validateEnvironmentConfiguredDirectly(DockerMachine dockerMachine, Map<String, String> expectedEnvironment) {
         ProcessBuilder process = dockerMachine.configuredDockerComposeProcess();
 
         Map<String, String> environment = process.environment();

--- a/docker-compose-rule-core/src/test/java/com/palantir/docker/compose/connection/StateShould.java
+++ b/docker-compose-rule-core/src/test/java/com/palantir/docker/compose/connection/StateShould.java
@@ -18,8 +18,6 @@ package com.palantir.docker.compose.connection;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 
-import java.io.IOException;
-
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -30,7 +28,7 @@ public class StateShould {
     public final ExpectedException exception = ExpectedException.none();
 
     @Test
-    public void parse_actual_docker_compose_output_when_state_is_Up() throws IOException, InterruptedException {
+    public void parse_actual_docker_compose_output_when_state_is_Up() {
         String psOutput =
                 "       Name                      Command               State                                         Ports                                        \n"
                         + "-------------------------------------------------------------------------------------------------------------------------------------------------\n"
@@ -41,7 +39,7 @@ public class StateShould {
     }
 
     @Test
-    public void parse_actual_docker_compose_output_when_state_is_Exit() throws IOException, InterruptedException {
+    public void parse_actual_docker_compose_output_when_state_is_Exit() {
         String psOutput =
                 "       Name                      Command               State                                         Ports                                        \n"
                         + "-------------------------------------------------------------------------------------------------------------------------------------------------\n"
@@ -52,7 +50,7 @@ public class StateShould {
     }
 
     @Test
-    public void throw_on_unknown_state() throws IOException, InterruptedException {
+    public void throw_on_unknown_state() {
         String psOutput =
                 "       Name                      Command               State                                         Ports                                        \n"
                         + "-------------------------------------------------------------------------------------------------------------------------------------------------\n"

--- a/docker-compose-rule-core/src/test/java/com/palantir/docker/compose/execution/ConflictingContainerRemovingDockerComposeShould.java
+++ b/docker-compose-rule-core/src/test/java/com/palantir/docker/compose/execution/ConflictingContainerRemovingDockerComposeShould.java
@@ -15,7 +15,7 @@
  */
 package com.palantir.docker.compose.execution;
 
-import static org.mockito.Matchers.anySet;
+import static org.mockito.Matchers.anySetOf;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -91,7 +91,7 @@ public class ConflictingContainerRemovingDockerComposeShould {
         doThrow(new DockerExecutionException("The name \"" + conflictingContainer + "\" is already in use"))
                 .doNothing()
                 .when(dockerCompose).up();
-        doThrow(DockerExecutionException.class).when(docker).rm(anySet());
+        doThrow(DockerExecutionException.class).when(docker).rm(anySetOf(String.class));
 
         ConflictingContainerRemovingDockerCompose conflictingContainerRemovingDockerCompose =
                 new ConflictingContainerRemovingDockerCompose(dockerCompose, docker);
@@ -107,7 +107,7 @@ public class ConflictingContainerRemovingDockerComposeShould {
         doThrow(new DockerExecutionException("The name \"" + conflictingContainer + "\" is already in use"))
                 .doNothing()
                 .when(dockerCompose).up();
-        doThrow(RuntimeException.class).when(docker).rm(anySet());
+        doThrow(RuntimeException.class).when(docker).rm(anySetOf(String.class));
 
         exception.expect(RuntimeException.class);
         ConflictingContainerRemovingDockerCompose conflictingContainerRemovingDockerCompose =

--- a/docker-compose-rule-core/src/test/java/com/palantir/docker/compose/execution/DockerCommandLocationsShould.java
+++ b/docker-compose-rule-core/src/test/java/com/palantir/docker/compose/execution/DockerCommandLocationsShould.java
@@ -39,7 +39,7 @@ public class DockerCommandLocationsShould {
     }
 
     @Test public void
-    provide_the_first_docker_command_location_if_it_exists() throws IOException {
+    provide_the_first_docker_command_location_if_it_exists() {
         DockerCommandLocations dockerCommandLocations = new DockerCommandLocations(
                 badLocation,
                 goodLocation,

--- a/docker-compose-rule-core/src/test/java/com/palantir/docker/compose/execution/DockerComposeShould.java
+++ b/docker-compose-rule-core/src/test/java/com/palantir/docker/compose/execution/DockerComposeShould.java
@@ -222,11 +222,11 @@ public class DockerComposeShould {
         assertThat(processCompose.run(DockerComposeRunOption.options("-it"), "container_1", DockerComposeRunArgument.arguments("ls", "-l")), is(lsString));
     }
 
-    private void addProcessToExecutor(DockerComposeExecutable dockerComposeExecutable, Process process, String... commands) throws Exception {
+    private static void addProcessToExecutor(DockerComposeExecutable dockerComposeExecutable, Process process, String... commands) throws Exception {
         when(dockerComposeExecutable.execute(commands)).thenReturn(process);
     }
 
-    private Process processWithOutput(String output) {
+    private static Process processWithOutput(String output) {
         Process mockedProcess = mock(Process.class);
         when(mockedProcess.getInputStream()).thenReturn(toInputStream(output));
         when(mockedProcess.exitValue()).thenReturn(0);

--- a/docker-compose-rule-core/src/test/java/com/palantir/docker/compose/execution/DockerComposeShould.java
+++ b/docker-compose-rule-core/src/test/java/com/palantir/docker/compose/execution/DockerComposeShould.java
@@ -55,7 +55,7 @@ public class DockerComposeShould {
     private final Container container = mock(Container.class);
 
     @Before
-    public void setup() throws IOException, InterruptedException {
+    public void setup() throws IOException {
         when(dockerMachine.getIp()).thenReturn("0.0.0.0");
         when(executor.execute(anyVararg())).thenReturn(executedProcess);
         when(executedProcess.getInputStream()).thenReturn(toInputStream("0.0.0.0:7000->7000/tcp"));
@@ -96,7 +96,7 @@ public class DockerComposeShould {
     }
 
     @Test
-    public void call_docker_compose_with_no_colour_flag_on_logs() throws IOException, InterruptedException {
+    public void call_docker_compose_with_no_colour_flag_on_logs() throws IOException {
         when(executedProcess.getInputStream()).thenReturn(
                 toInputStream("docker-compose version 1.5.6, build 1ad8866"),
                 toInputStream("logs"));
@@ -108,7 +108,7 @@ public class DockerComposeShould {
 
     @Test
     public void call_docker_compose_with_the_follow_flag_when_the_version_is_at_least_1_7_0_on_logs()
-            throws IOException, InterruptedException {
+            throws IOException {
         when(executedProcess.getInputStream()).thenReturn(
                 toInputStream("docker-compose version 1.7.0, build 1ad8866"),
                 toInputStream("logs"));

--- a/docker-compose-rule-core/src/test/java/com/palantir/docker/compose/execution/DockerComposeVersionShould.java
+++ b/docker-compose-rule-core/src/test/java/com/palantir/docker/compose/execution/DockerComposeVersionShould.java
@@ -27,17 +27,17 @@ import org.junit.Test;
 public class DockerComposeVersionShould {
 
     @Test
-    public void compare_major_versions_first() throws Exception {
+    public void compare_major_versions_first() {
         assertThat(Version.valueOf("2.1.0").compareTo(Version.valueOf("1.2.1")), greaterThan(0));
     }
 
     @Test
-    public void compare_minor_versions_when_major_versions_are_the_same() throws Exception {
+    public void compare_minor_versions_when_major_versions_are_the_same() {
         assertThat(Version.valueOf("2.1.7").compareTo(Version.valueOf("2.3.2")), lessThan(0));
     }
 
     @Test
-    public void return_equals_for_the_same_version_strings() throws Exception {
+    public void return_equals_for_the_same_version_strings() {
         assertThat(Version.valueOf("2.1.2").compareTo(Version.valueOf("2.1.2")), is(0));
     }
 

--- a/docker-compose-rule-core/src/test/java/com/palantir/docker/compose/execution/DockerShould.java
+++ b/docker-compose-rule-core/src/test/java/com/palantir/docker/compose/execution/DockerShould.java
@@ -33,7 +33,7 @@ public class DockerShould {
     private final Process executedProcess = mock(Process.class);
 
     @Before
-    public void setup() throws IOException, InterruptedException {
+    public void setup() throws IOException {
         when(executor.execute(anyVararg())).thenReturn(executedProcess);
         when(executedProcess.getInputStream()).thenReturn(toInputStream("0.0.0.0:7000->7000/tcp"));
         when(executedProcess.exitValue()).thenReturn(0);

--- a/docker-compose-rule-core/src/test/java/com/palantir/docker/compose/execution/RetryerShould.java
+++ b/docker-compose-rule-core/src/test/java/com/palantir/docker/compose/execution/RetryerShould.java
@@ -20,7 +20,6 @@ import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.lessThan;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.fail;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -30,9 +29,13 @@ import com.palantir.docker.compose.utils.MockitoMultiAnswer;
 import java.util.concurrent.TimeUnit;
 import org.joda.time.Duration;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
 
+@RunWith(MockitoJUnitRunner.class)
 public class RetryerShould {
-    private final Retryer.RetryableDockerOperation<String> operation = mock(Retryer.RetryableDockerOperation.class);
+    @Mock private Retryer.RetryableDockerOperation<String> operation;
     private final Retryer retryer = new Retryer(1, Duration.millis(0));
 
     @Test

--- a/docker-compose-rule-core/src/test/java/com/palantir/docker/compose/logging/FileLogCollectorShould.java
+++ b/docker-compose-rule-core/src/test/java/com/palantir/docker/compose/logging/FileLogCollectorShould.java
@@ -198,7 +198,7 @@ public class FileLogCollectorShould {
         logCollector.startCollecting(compose);
     }
 
-    private File cannotBeCreatedDirectory() {
+    private static File cannotBeCreatedDirectory() {
         File cannotBeCreatedDirectory = mock(File.class);
         when(cannotBeCreatedDirectory.isFile()).thenReturn(false);
         when(cannotBeCreatedDirectory.mkdirs()).thenReturn(false);

--- a/docker-compose-rule-core/src/test/java/com/palantir/docker/compose/logging/FileLogCollectorShould.java
+++ b/docker-compose-rule-core/src/test/java/com/palantir/docker/compose/logging/FileLogCollectorShould.java
@@ -71,7 +71,7 @@ public class FileLogCollectorShould {
     }
 
     @Test
-    public void create_the_log_directory_if_it_does_not_already_exist() throws IOException {
+    public void create_the_log_directory_if_it_does_not_already_exist() {
         File doesNotExistYetDirectory = logDirectoryParent.getRoot()
                 .toPath()
                 .resolve("doesNotExist")
@@ -81,8 +81,7 @@ public class FileLogCollectorShould {
     }
 
     @Test
-    public void throw_exception_when_created_if_the_log_directory_does_not_exist_and_cannot_be_created()
-            throws IOException {
+    public void throw_exception_when_created_if_the_log_directory_does_not_exist_and_cannot_be_created() {
         File cannotBeCreatedDirectory = cannotBeCreatedDirectory();
 
         exception.expect(IllegalArgumentException.class);

--- a/docker-compose-rule-core/src/test/java/com/palantir/docker/compose/matchers/AvailablePortMatcherShould.java
+++ b/docker-compose-rule-core/src/test/java/com/palantir/docker/compose/matchers/AvailablePortMatcherShould.java
@@ -32,13 +32,13 @@ public class AvailablePortMatcherShould {
     public ExpectedException exception = ExpectedException.none();
 
     @Test
-    public void succeed_when_there_are_no_unavailable_ports() throws Exception {
+    public void succeed_when_there_are_no_unavailable_ports() {
         List<DockerPort> unavailablePorts = emptyList();
         assertThat(unavailablePorts, areAvailable());
     }
 
     @Test
-    public void throw_exception_when_there_are_some_unavailable_ports() throws Exception {
+    public void throw_exception_when_there_are_some_unavailable_ports() {
         List<DockerPort> unavailablePorts = newArrayList(new DockerPort("0.0.0.0", 1234, 1234),
                                                          new DockerPort("1.2.3.4", 2345, 3456));
         exception.expect(AssertionError.class);

--- a/docker-compose-rule-core/src/test/java/com/palantir/docker/compose/utils/MockitoMultiAnswer.java
+++ b/docker-compose-rule-core/src/test/java/com/palantir/docker/compose/utils/MockitoMultiAnswer.java
@@ -30,6 +30,7 @@ public class MockitoMultiAnswer<T> implements Answer<T> {
         this.invocationHandlers = ImmutableList.copyOf(invocationHandlers);
     }
 
+    @SafeVarargs
     public static <T> MockitoMultiAnswer<T> of(Function<InvocationOnMock, T>... invocationHandlers) {
         return new MockitoMultiAnswer<>(Arrays.asList(invocationHandlers));
     }

--- a/docker-compose-rule-junit4/src/test/java/com/palantir/docker/compose/AggressiveShutdownWithNetworkCleanupStrategyIntegrationTest.java
+++ b/docker-compose-rule-junit4/src/test/java/com/palantir/docker/compose/AggressiveShutdownWithNetworkCleanupStrategyIntegrationTest.java
@@ -46,7 +46,7 @@ public class AggressiveShutdownWithNetworkCleanupStrategyIntegrationTest {
         assertThat(parseLinesFromOutputString(rule.docker().listNetworks()), is(networksBeforeRun));
     }
 
-    private Set<String> parseLinesFromOutputString(String output) {
+    private static Set<String> parseLinesFromOutputString(String output) {
         return Sets.newHashSet(Arrays.asList(output.split("\n")));
     }
 }

--- a/docker-compose-rule-junit4/src/test/java/com/palantir/docker/compose/DockerComposeRuleIntegrationTest.java
+++ b/docker-compose-rule-junit4/src/test/java/com/palantir/docker/compose/DockerComposeRuleIntegrationTest.java
@@ -51,7 +51,7 @@ public class DockerComposeRuleIntegrationTest {
             .waitingForServices(ImmutableList.of("db3", "db4"), toAllHaveAllPortsOpen())
             .build();
 
-    private HealthCheck<List<Container>> toAllHaveAllPortsOpen() {
+    private static HealthCheck<List<Container>> toAllHaveAllPortsOpen() {
         return containers -> {
             boolean healthy = containers.stream()
                     .map(Container::areAllPortsOpen)
@@ -67,7 +67,7 @@ public class DockerComposeRuleIntegrationTest {
     @Rule
     public ExpectedException exception = ExpectedException.none();
 
-    private void forEachContainer(Consumer<String> consumer) {
+    private static void forEachContainer(Consumer<String> consumer) {
         CONTAINERS.forEach(consumer);
     }
 

--- a/docker-compose-rule-junit4/src/test/java/com/palantir/docker/compose/DockerComposeRuleIntegrationTest.java
+++ b/docker-compose-rule-junit4/src/test/java/com/palantir/docker/compose/DockerComposeRuleIntegrationTest.java
@@ -72,14 +72,14 @@ public class DockerComposeRuleIntegrationTest {
     }
 
     @Test
-    public void should_run_docker_compose_up_using_the_specified_docker_compose_file_to_bring_postgres_up() throws InterruptedException, IOException {
+    public void should_run_docker_compose_up_using_the_specified_docker_compose_file_to_bring_postgres_up() {
         forEachContainer(container -> {
             assertThat(docker.containers().container(container).port(5432).isListeningNow(), is(true));
         });
     }
 
     @Test
-    public void after_test_is_executed_the_launched_postgres_container_is_no_longer_listening() throws IOException, InterruptedException {
+    public void after_test_is_executed_the_launched_postgres_container_is_no_longer_listening() {
         docker.after();
 
         forEachContainer(container -> {
@@ -88,7 +88,7 @@ public class DockerComposeRuleIntegrationTest {
     }
 
     @Test
-    public void can_access_external_port_for_internal_port_of_machine() throws IOException, InterruptedException {
+    public void can_access_external_port_for_internal_port_of_machine() {
         forEachContainer(container -> {
             assertThat(docker.containers().container(container).port(5432).isListeningNow(), is(true));
         });

--- a/docker-compose-rule-junit4/src/test/java/com/palantir/docker/compose/HostNetworkedPortsIntegrationTest.java
+++ b/docker-compose-rule-junit4/src/test/java/com/palantir/docker/compose/HostNetworkedPortsIntegrationTest.java
@@ -31,7 +31,7 @@ public class HostNetworkedPortsIntegrationTest {
             .waitingForHostNetworkedPort(5432, toBeOpen())
             .build();
 
-    private HealthCheck<DockerPort> toBeOpen() {
+    private static HealthCheck<DockerPort> toBeOpen() {
         return port -> SuccessOrFailure.fromBoolean(port.isListeningNow(), "" + port + "was not listening");
     }
 

--- a/docker-compose-rule-junit4/src/test/java/com/palantir/docker/compose/logging/LoggingIntegrationTest.java
+++ b/docker-compose-rule-junit4/src/test/java/com/palantir/docker/compose/logging/LoggingIntegrationTest.java
@@ -37,7 +37,7 @@ public class LoggingIntegrationTest {
     private DockerComposeRule dockerComposeRule;
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         dockerComposeRule = DockerComposeRule.builder()
                 .file("src/test/resources/docker-compose.yaml")
                 .waitingForService("db", toHaveAllPortsOpen())


### PR DESCRIPTION
Cleanup a number of compiler/Eclipse warnings:

 * Annotate MockitoMultiAnswer.of with SafeVarargs
 * Use generics-friendly anySetOf
 * Use MockitoJUnitRule in RetryerShould
 * Don't declare exceptions that aren't thrown
 * Declare methods as static when they can be