### PR TITLE
Add option to accept all certificates

### DIFF
--- a/docker-compose-rule-junit4/src/main/java/com/palantir/docker/compose/DockerComposeRule.java
+++ b/docker-compose-rule-junit4/src/main/java/com/palantir/docker/compose/DockerComposeRule.java
@@ -38,6 +38,12 @@ import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
 import java.security.cert.X509Certificate;
 import java.util.List;
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.HttpsURLConnection;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSession;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
 import org.immutables.value.Value;
 import org.joda.time.Duration;
 import org.joda.time.ReadableDuration;
@@ -45,7 +51,6 @@ import org.junit.rules.ExternalResource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.net.ssl.*;
 
 @Value.Immutable
 @CustomImmutablesStyle

--- a/docker-compose-rule-junit4/src/main/java/com/palantir/docker/compose/DockerComposeRule.java
+++ b/docker-compose-rule-junit4/src/main/java/com/palantir/docker/compose/DockerComposeRule.java
@@ -34,6 +34,9 @@ import com.palantir.docker.compose.logging.FileLogCollector;
 import com.palantir.docker.compose.logging.LogCollector;
 import com.palantir.docker.compose.logging.LogDirectory;
 import java.io.IOException;
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.X509Certificate;
 import java.util.List;
 import org.immutables.value.Value;
 import org.joda.time.Duration;
@@ -41,6 +44,8 @@ import org.joda.time.ReadableDuration;
 import org.junit.rules.ExternalResource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import javax.net.ssl.*;
 
 @Value.Immutable
 @CustomImmutablesStyle
@@ -189,6 +194,39 @@ public abstract class DockerComposeRule extends ExternalResource {
         public Builder skipShutdown(boolean skipShutdown) {
             if (skipShutdown) {
                 return shutdownStrategy(ShutdownStrategy.SKIP);
+            }
+
+            return this;
+        }
+
+        public Builder acceptAllCerts() {
+            try {
+                TrustManager trm = new X509TrustManager() {
+                    public X509Certificate[] getAcceptedIssuers() {
+                        return null;
+                    }
+
+                    public void checkClientTrusted(X509Certificate[] certs, String authType) {
+
+                    }
+
+                    public void checkServerTrusted(X509Certificate[] certs, String authType) {
+                    }
+                };
+
+                SSLContext sc = SSLContext.getInstance("SSL");
+                sc.init(null, new TrustManager[] { trm }, null);
+                HttpsURLConnection.setDefaultSSLSocketFactory(sc.getSocketFactory());
+
+                HostnameVerifier allHostsValid = new HostnameVerifier() {
+                    public boolean verify(String hostname, SSLSession session) {
+                        return true;
+                    }
+                };
+
+                HttpsURLConnection.setDefaultHostnameVerifier(allHostsValid);
+            } catch (NoSuchAlgorithmException | KeyManagementException e) {
+                log.error("Could not set all-trusting security manager", e);
             }
 
             return this;


### PR DESCRIPTION
Adds a builder method that installs a trust-all TrustManager and HostVerifier. 
Could be useful in tests that involve SSL communication with self-signed certificates. 

E.g.:
```
@ClassRule
public static DockerComposeRule docker = DockerComposeRule.builder()
            .file("src/test/resources/docker-compose.yml")
            .acceptAllCerts()
            .build();
```