### PR TITLE
Optionally don't accept status code 404 as "healthy"

### DIFF
--- a/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/connection/Container.java
+++ b/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/connection/Container.java
@@ -42,13 +42,21 @@ public class Container {
         return containerName;
     }
 
+    public SuccessOrFailure portIsListeningOnHttpAndCheckStatus2xx(int internalPort, Function<DockerPort, String> urlFunction) {
+        return portIsListeningOnHttp(internalPort, urlFunction, true);
+    }
+
     public SuccessOrFailure portIsListeningOnHttp(int internalPort, Function<DockerPort, String> urlFunction) {
+        return portIsListeningOnHttp(internalPort, urlFunction, false);
+    }
+
+    public SuccessOrFailure portIsListeningOnHttp(int internalPort, Function<DockerPort, String> urlFunction, boolean andCheckStatus) {
         try {
             DockerPort port = port(internalPort);
             if (!port.isListeningNow()) {
                 return SuccessOrFailure.failure(internalPort + " is not listening");
             }
-            if (!port.isHttpResponding(urlFunction)) {
+            if (!port.isHttpResponding(urlFunction, andCheckStatus)) {
                 return SuccessOrFailure.failure(internalPort + " does not have a http response from " + urlFunction.apply(port));
             }
             return SuccessOrFailure.success();
@@ -78,7 +86,7 @@ public class Container {
                            .stream()
                            .filter(port -> port.getInternalPort() == internalPort)
                            .findFirst()
-                           .orElseThrow(() -> new IllegalArgumentException("No internal port '" + internalPort + "' for container '" + containerName + "'"));
+                           .orElseThrow(() -> new IllegalArgumentException("No internal port '" + internalPort + "' for container '" + containerName + "': " + portMappings));
     }
 
     public void start() throws IOException, InterruptedException {

--- a/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/connection/DockerPort.java
+++ b/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/connection/DockerPort.java
@@ -66,7 +66,7 @@ public class DockerPort {
         }
     }
 
-    public boolean isHttpResponding(Function<DockerPort, String> urlFunction) {
+    public boolean isHttpResponding(Function<DockerPort, String> urlFunction, boolean andCheckStatus) {
         URL url;
         try {
             String urlString = urlFunction.apply(this);
@@ -85,7 +85,7 @@ public class DockerPort {
             return false;
         } catch (FileNotFoundException e) {
             log.debug("Received 404, assuming port active");
-            return true;
+            return !andCheckStatus;
         } catch (SSLHandshakeException e) {
             log.debug("Received bad SSL response, assuming port inactive");
             return false;

--- a/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/connection/waiting/HealthChecks.java
+++ b/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/connection/waiting/HealthChecks.java
@@ -28,6 +28,10 @@ public final class HealthChecks {
         return container -> container.portIsListeningOnHttp(internalPort, urlFunction);
     }
 
+    public static HealthCheck<Container> toRespond2xxOverHttp(int internalPort, Function<DockerPort, String> urlFunction) {
+        return container -> container.portIsListeningOnHttpAndCheckStatus2xx(internalPort, urlFunction);
+    }
+
     public static HealthCheck<Container> toHaveAllPortsOpen() {
         return Container::areAllPortsOpen;
     }

--- a/docker-compose-rule-core/src/test/java/com/palantir/docker/compose/configuration/MockDockerEnvironment.java
+++ b/docker-compose-rule-core/src/test/java/com/palantir/docker/compose/configuration/MockDockerEnvironment.java
@@ -50,13 +50,13 @@ public class MockDockerEnvironment {
 
     public DockerPort availableHttpService(String service, String ip, int externalPortNumber, int internalPortNumber) throws Exception {
         DockerPort port = availableService(service, ip, externalPortNumber, internalPortNumber);
-        doReturn(true).when(port).isHttpResponding(any());
+        doReturn(true).when(port).isHttpResponding(any(), false);
         return port;
     }
 
     public DockerPort unavailableHttpService(String service, String ip, int externalPortNumber, int internalPortNumber) throws Exception {
         DockerPort port = availableService(service, ip, externalPortNumber, internalPortNumber);
-        doReturn(false).when(port).isHttpResponding(any());
+        doReturn(false).when(port).isHttpResponding(any(), false);
         return port;
     }
 

--- a/docker-compose-rule-core/src/test/java/com/palantir/docker/compose/configuration/MockDockerEnvironment.java
+++ b/docker-compose-rule-core/src/test/java/com/palantir/docker/compose/configuration/MockDockerEnvironment.java
@@ -16,6 +16,7 @@
 package com.palantir.docker.compose.configuration;
 
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
@@ -50,13 +51,13 @@ public class MockDockerEnvironment {
 
     public DockerPort availableHttpService(String service, String ip, int externalPortNumber, int internalPortNumber) throws Exception {
         DockerPort port = availableService(service, ip, externalPortNumber, internalPortNumber);
-        doReturn(true).when(port).isHttpResponding(any(), false);
+        doReturn(true).when(port).isHttpResponding(any(), eq(false));
         return port;
     }
 
     public DockerPort unavailableHttpService(String service, String ip, int externalPortNumber, int internalPortNumber) throws Exception {
         DockerPort port = availableService(service, ip, externalPortNumber, internalPortNumber);
-        doReturn(false).when(port).isHttpResponding(any(), false);
+        doReturn(false).when(port).isHttpResponding(any(), eq(false));
         return port;
     }
 


### PR DESCRIPTION
By default "waiting for cluster to be healthy" will assume that a 404 response is OK. 
In some cases this can be tricky (e.g. waiting for larger-than-usual web applications to deploy before starting the actual test).
Add a new method that will also check for status 200.