### PR TITLE
Speed up test teardown

### DIFF
--- a/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/configuration/ShutdownStrategy.java
+++ b/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/configuration/ShutdownStrategy.java
@@ -9,6 +9,7 @@ import com.palantir.docker.compose.execution.AggressiveShutdownWithNetworkCleanu
 import com.palantir.docker.compose.execution.Docker;
 import com.palantir.docker.compose.execution.DockerCompose;
 import com.palantir.docker.compose.execution.GracefulShutdownStrategy;
+import com.palantir.docker.compose.execution.KillDownShutdownStrategy;
 import com.palantir.docker.compose.execution.SkipShutdownStrategy;
 import java.io.IOException;
 
@@ -22,6 +23,7 @@ public interface ShutdownStrategy {
     ShutdownStrategy GRACEFUL = new GracefulShutdownStrategy();
     ShutdownStrategy SKIP = new SkipShutdownStrategy();
     ShutdownStrategy AGGRESSIVE_WITH_NETWORK_CLEANUP = new AggressiveShutdownWithNetworkCleanupStrategy();
+    ShutdownStrategy KILL_DOWN = new KillDownShutdownStrategy();
 
     void shutdown(DockerCompose dockerCompose, Docker docker) throws IOException, InterruptedException;
 

--- a/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/execution/KillDownShutdownStrategy.java
+++ b/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/execution/KillDownShutdownStrategy.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ */
+
+package com.palantir.docker.compose.execution;
+
+import com.palantir.docker.compose.configuration.ShutdownStrategy;
+import java.io.IOException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Shuts down fast but cleanly by issuing a kill (fast shutdown) followed by a down (thorough cleanup)
+ *
+ * <p>"down" would be ideal as a single command if it didn't first execute an impotent SIGTERM, which
+ * many Docker images simply ignore due to being run by bash as process 1. We don't need a graceful
+ * shutdown period anyway since the tests are done and we're destroying the docker image.
+ */
+public class KillDownShutdownStrategy implements ShutdownStrategy {
+
+    private static final Logger log = LoggerFactory.getLogger(KillDownShutdownStrategy.class);
+
+    @Override
+    public void shutdown(DockerCompose dockerCompose, Docker docker)
+            throws IOException, InterruptedException {
+        log.debug("Killing docker-compose cluster");
+        dockerCompose.kill();
+        log.debug("Downing docker-compose cluster");
+        dockerCompose.down();
+        log.debug("docker-compose cluster killed");
+    }
+}

--- a/docker-compose-rule-core/src/test/java/com/palantir/docker/compose/execution/KillDownShutdownStrategyShould.java
+++ b/docker-compose-rule-core/src/test/java/com/palantir/docker/compose/execution/KillDownShutdownStrategyShould.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
+ */
+
+package com.palantir.docker.compose.execution;
+
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+
+import com.palantir.docker.compose.configuration.ShutdownStrategy;
+import org.junit.Test;
+import org.mockito.InOrder;
+
+public class KillDownShutdownStrategyShould {
+
+    @Test
+    public void call_kill_then_down() throws Exception {
+        DockerCompose dockerCompose = mock(DockerCompose.class);
+        Docker docker = mock(Docker.class);
+
+        ShutdownStrategy.KILL_DOWN.shutdown(dockerCompose, docker);
+
+        InOrder inOrder = inOrder(dockerCompose);
+        inOrder.verify(dockerCompose).kill();
+        inOrder.verify(dockerCompose).down();
+        inOrder.verifyNoMoreInteractions();
+    }
+}

--- a/docker-compose-rule-junit4/src/main/java/com/palantir/docker/compose/DockerComposeRule.java
+++ b/docker-compose-rule-junit4/src/main/java/com/palantir/docker/compose/DockerComposeRule.java
@@ -91,7 +91,7 @@ public abstract class DockerComposeRule extends ExternalResource {
 
     @Value.Default
     public ShutdownStrategy shutdownStrategy() {
-        return ShutdownStrategy.GRACEFUL;
+        return ShutdownStrategy.KILL_DOWN;
     }
 
     @Value.Default

--- a/docker-compose-rule-junit4/src/test/resources/docker-compose.yaml
+++ b/docker-compose-rule-junit4/src/test/resources/docker-compose.yaml
@@ -1,35 +1,23 @@
 db:
-  image: kiasaki/alpine-postgres
-  environment:
-    - "POSTGRES_DB=source"
-    - "POSTGRES_USER=palantir"
-    - "POSTGRES_PASSWORD=palantir"
+  image: appropriate/nc
+  command: /bin/sh -c 'echo server started && nc -lk 5432'
   ports:
     - "5432"
 
 db2:
-  image: kiasaki/alpine-postgres
-  environment:
-    - "POSTGRES_DB=source"
-    - "POSTGRES_USER=palantir"
-    - "POSTGRES_PASSWORD=palantir"
+  image: appropriate/nc
+  command: /bin/sh -c 'echo server started && nc -lk 5432'
   ports:
     - "5432"
 
 db3:
-  image: kiasaki/alpine-postgres
-  environment:
-    - "POSTGRES_DB=source"
-    - "POSTGRES_USER=palantir"
-    - "POSTGRES_PASSWORD=palantir"
+  image: appropriate/nc
+  command: /bin/sh -c 'echo server started && nc -lk 5432'
   ports:
     - "5432"
 
 db4:
-  image: kiasaki/alpine-postgres
-  environment:
-    - "POSTGRES_DB=source"
-    - "POSTGRES_USER=palantir"
-    - "POSTGRES_PASSWORD=palantir"
+  image: appropriate/nc
+  command: /bin/sh -c 'echo server started && nc -lk 5432'
   ports:
     - "5432"


### PR DESCRIPTION
Most Docker containers ignore the SIGTERM they are sent by 'docker-compose down', resulting in a pointless 10 second delay per test. The 'aggressive' shutdown strategies are unnecessarily complex, however, as we can simply issue a 'docker-compose kill' first, and rely on 'docker-compose down' to clean up gracefully. There is also no need to issue a 'docker-compose rm' as we already pass '--volumes' to 'down'. This new KillDownShutdownStrategy should be safe for us to default users to.