### PR TITLE
Slightly improved logging for Retryer.

### DIFF
--- a/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/execution/Retryer.java
+++ b/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/execution/Retryer.java
@@ -44,13 +44,15 @@ public class Retryer {
                 return operation.call();
             } catch (DockerExecutionException e) {
                 lastExecutionException = e;
-                log.warn("Caught exception: {}. Retrying after {}", e.getMessage(), delay);
+                log.warn("Caught exception: {}");
+                log.warn("Retrying after {}", e.getMessage(), delay);
                 if (i < retryAttempts) {
                     Thread.sleep(delay.getMillis());
                 }
             }
         }
 
+        log.error("Exhausted all retry attempts. Tried {} times.", retryAttempts);
         throw lastExecutionException;
     }
 }

--- a/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/execution/Retryer.java
+++ b/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/execution/Retryer.java
@@ -44,8 +44,8 @@ public class Retryer {
                 return operation.call();
             } catch (DockerExecutionException e) {
                 lastExecutionException = e;
-                log.warn("Caught exception: {}");
-                log.warn("Retrying after {}", e.getMessage(), delay);
+                log.warn("Caught exception: {}", e.getMessage());
+                log.warn("Retrying after {}", delay);
                 if (i < retryAttempts) {
                     Thread.sleep(delay.getMillis());
                 }


### PR DESCRIPTION
**Reasoning**
Was pretty tricky to work out exactly what was going on from DockerComposeRule logs from CircleCI as things got mushed together with DockerCompose error output.

**Changes**
- Ensure newline is printed between docker output and Retrying log mess…ages.
- Add log line when all retries are exhausted.

Also wondering whether you want to add tests for log messages?