### PR TITLE
Fix docker health check to work on Windows.

### DIFF
--- a/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/execution/Docker.java
+++ b/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/execution/Docker.java
@@ -25,6 +25,8 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
+import org.apache.commons.lang3.SystemUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -41,6 +43,7 @@ public class Docker {
                     + "{{if eq .State.Health.Status \"healthy\"}}HEALTHY"
                     + "{{else}}UNHEALTHY{{end}}"
                     + "{{else}}HEALTHY{{end}}";
+    private static final String HEALTH_STATUS_FORMAT_WINDOWS = HEALTH_STATUS_FORMAT.replaceAll("\"", "`\"");
 
     public static Version version() throws IOException, InterruptedException {
         Command command = new Command(
@@ -58,8 +61,8 @@ public class Docker {
     }
 
     public State state(String containerId) throws IOException, InterruptedException {
-        String stateString = command.execute(
-                Command.throwingOnError(), "inspect", HEALTH_STATUS_FORMAT, containerId);
+        String formatString = SystemUtils.IS_OS_WINDOWS ? HEALTH_STATUS_FORMAT_WINDOWS : HEALTH_STATUS_FORMAT;
+        String stateString = command.execute(Command.throwingOnError(), "inspect", formatString, containerId);
         return State.valueOf(stateString);
     }
 


### PR DESCRIPTION
Using version 0.31.0 and the latest stable docker release (version 1.13.1) on Windows, both of the tests in ContainerIntegrationTests fail with the following error:
```
com.palantir.docker.compose.execution.DockerExecutionException: 'docker inspect --format={{if not .State.Running}}DOWN{{else if .State.Paused}}PAUSED{{else if index .State "Health"}}{{if eq .State.Health.Status "healthy"}}HEALTHY{{else}}UNHEALTHY{{end}}{{else}}HEALTHY{{end}} 0f0d3e40ef642d0b1201f23e50994d531c33e44fd7f05104dd111d98bdf0dd57' returned exit code 64
The output was:
Template parsing error: template: :1: function "Health" not defined
```

This is down to the way the double-quotes need to be escaped in windows, which is to use the back-tick. My commit performs this escaping when running on Windows.