### PR TITLE
Fix call to docker-compose exec in integration test.

### DIFF
--- a/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/execution/DefaultDockerCompose.java
+++ b/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/execution/DefaultDockerCompose.java
@@ -140,7 +140,11 @@ public class DefaultDockerCompose implements DockerCompose {
 
     private static String[] constructFullDockerComposeExecArguments(DockerComposeExecOption dockerComposeExecOption,
             String containerName, DockerComposeExecArgument dockerComposeExecArgument) {
+        // The "-T" option here disables pseudo-TTY allocation, which is not useful here since we are not using
+        // terminal features here (e.g. we are not sending ^C to kill the executed process).
+        // Disabling pseudo-TTY allocation means this will work on OS's that don't support TTY (i.e. Windows)
         ImmutableList<String> fullArgs = new ImmutableList.Builder<String>().add("exec")
+                                                                            .add("-T")
                                                                             .addAll(dockerComposeExecOption.options())
                                                                             .add(containerName)
                                                                             .addAll(dockerComposeExecArgument.arguments())

--- a/docker-compose-rule-core/src/test/java/com/palantir/docker/compose/execution/DockerComposeShould.java
+++ b/docker-compose-rule-core/src/test/java/com/palantir/docker/compose/execution/DockerComposeShould.java
@@ -172,7 +172,7 @@ public class DockerComposeShould {
             throws IOException, InterruptedException {
         when(executedProcess.getInputStream()).thenReturn(toInputStream("docker-compose version 1.7.0rc1, build 1ad8866"));
         compose.exec(options("-d"), "container_1", arguments("ls"));
-        verify(executor, times(1)).execute("exec", "-d", "container_1", "ls");
+        verify(executor, times(1)).execute("exec", "-T", "-d", "container_1", "ls");
     }
 
     @Test
@@ -193,15 +193,15 @@ public class DockerComposeShould {
 
     @Test
     public void return_the_output_from_the_executed_process_on_docker_compose_exec() throws Exception {
-        String lsString = "-rw-r--r--  1 user  1318458867  11326 Mar  9 17:47 LICENSE\n"
-                + "-rw-r--r--  1 user  1318458867  12570 May 12 14:51 README.md";
+        String lsString = String.format("-rw-r--r--  1 user  1318458867  11326 Mar  9 17:47 LICENSE%n"
+                                        + "-rw-r--r--  1 user  1318458867  12570 May 12 14:51 README.md");
 
         String versionString = "docker-compose version 1.7.0rc1, build 1ad8866";
 
         DockerComposeExecutable processExecutor = mock(DockerComposeExecutable.class);
 
         addProcessToExecutor(processExecutor, processWithOutput(versionString), "-v");
-        addProcessToExecutor(processExecutor, processWithOutput(lsString), "exec", "container_1", "ls", "-l");
+        addProcessToExecutor(processExecutor, processWithOutput(lsString), "exec", "-T", "container_1", "ls", "-l");
 
         DockerCompose processCompose = new DefaultDockerCompose(processExecutor, dockerMachine);
 
@@ -210,8 +210,8 @@ public class DockerComposeShould {
 
     @Test
     public void return_the_output_from_the_executed_process_on_docker_compose_run() throws Exception {
-        String lsString = "-rw-r--r--  1 user  1318458867  11326 Mar  9 17:47 LICENSE\n"
-                + "-rw-r--r--  1 user  1318458867  12570 May 12 14:51 README.md";
+        String lsString = String.format("-rw-r--r--  1 user  1318458867  11326 Mar  9 17:47 LICENSE%n"
+                                        + "-rw-r--r--  1 user  1318458867  12570 May 12 14:51 README.md");
 
         DockerComposeExecutable processExecutor = mock(DockerComposeExecutable.class);
 


### PR DESCRIPTION
Calls to docker-compose exec in Windows need the -T option (to disable
pseudo-tty allocation, which doesn't work in Windows without something
like winpty).

This commit adds the -T option to all calls to docker-compose exec.

Is there any reason not to disable pseudo-tty allocation? If so I could only add "-T" if on Windows.