### PR TITLE
Fix regex for splitting on newline characters to work on Windows too.

### DIFF
--- a/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/connection/ContainerNames.java
+++ b/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/connection/ContainerNames.java
@@ -27,7 +27,7 @@ public class ContainerNames {
     private ContainerNames() {}
 
     public static List<ContainerName> parseFromDockerComposePs(String psOutput) {
-        String[] psHeadAndBody = psOutput.split("-+\n");
+        String[] psHeadAndBody = psOutput.split("-+(\r|\n)+");
         if (psHeadAndBody.length < 2) {
             return emptyList();
         }
@@ -39,7 +39,7 @@ public class ContainerNames {
     }
 
     private static Stream<String> psBodyLines(String psBody) {
-        String[] lines = psBody.split("\n");
+        String[] lines = psBody.split("(\r|\n)+");
         return Arrays.stream(lines)
                 .map(String::trim)
                 .filter(line -> !line.isEmpty());

--- a/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/execution/DefaultDockerCompose.java
+++ b/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/execution/DefaultDockerCompose.java
@@ -176,7 +176,7 @@ public class DefaultDockerCompose implements DockerCompose {
     @Override
     public List<String> services() throws IOException, InterruptedException {
         String servicesOutput = command.execute(Command.throwingOnError(), "config", "--services");
-        return Arrays.asList(servicesOutput.split("\n"));
+        return Arrays.asList(servicesOutput.split("(\r|\n)+"));
     }
 
     /**

--- a/docker-compose-rule-core/src/test/java/com/palantir/docker/compose/connection/ContainerNameShould.java
+++ b/docker-compose-rule-core/src/test/java/com/palantir/docker/compose/connection/ContainerNameShould.java
@@ -51,6 +51,12 @@ public class ContainerNameShould {
     }
 
     @Test
+    public void allow_windows_newline_characters() {
+        List<ContainerName> names = ContainerNames.parseFromDockerComposePs("\r\n----\r\ndir_db_1 other line contents");
+        assertThat(names, contains(containerName("dir", "db", "1")));
+    }
+
+    @Test
     public void allow_containers_with_underscores_in_their_name() {
         List<ContainerName> names = ContainerNames.parseFromDockerComposePs("\n----\ndir_left_right_1 other line contents");
         assertThat(names, contains(containerName("dir", "left_right", "1")));


### PR DESCRIPTION
This fixes most integration tests on Windows (still a few more to go though!)