### PR TITLE
Ignore test that fails on Windows/Mac by design.

### DIFF
--- a/docker-compose-rule-junit4/src/test/java/com/palantir/docker/compose/HostNetworkedPortsIntegrationTest.java
+++ b/docker-compose-rule-junit4/src/test/java/com/palantir/docker/compose/HostNetworkedPortsIntegrationTest.java
@@ -17,27 +17,38 @@ package com.palantir.docker.compose;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
+import static org.junit.Assume.assumeTrue;
 
 import com.palantir.docker.compose.connection.DockerPort;
 import com.palantir.docker.compose.connection.waiting.HealthCheck;
 import com.palantir.docker.compose.connection.waiting.SuccessOrFailure;
-import org.junit.Rule;
+
+import org.apache.commons.lang3.SystemUtils;
 import org.junit.Test;
 
 public class HostNetworkedPortsIntegrationTest {
-    @Rule
-    public DockerComposeRule docker = DockerComposeRule.builder()
-            .file("src/test/resources/host-networked-docker-compose.yaml")
-            .waitingForHostNetworkedPort(5432, toBeOpen())
-            .build();
-
     private static HealthCheck<DockerPort> toBeOpen() {
         return port -> SuccessOrFailure.fromBoolean(port.isListeningNow(), "" + port + "was not listening");
     }
 
     @Test public void
-    can_access_host_networked_ports() {
-        assertThat(docker.hostNetworkedPort(5432).getInternalPort(), is(5432));
-        assertThat(docker.hostNetworkedPort(5432).getExternalPort(), is(5432));
+    can_access_host_networked_ports() throws Exception {
+        // On linux the docker host is running on localhost, so host ports are accessible through localhost.
+        // On Windows and Mac however, docker is being run in a linux VM. As such the docker host is the running
+        // VM, not localhost, and the ports are inaccessible from outside the VM.
+        // As such, this test will only run on linux.
+        assumeTrue("Host ports are only accessible on linux", SystemUtils.IS_OS_LINUX);
+
+        DockerComposeRule docker = DockerComposeRule.builder()
+                .file("src/test/resources/host-networked-docker-compose.yaml")
+                .waitingForHostNetworkedPort(5432, toBeOpen())
+                .build();
+        try {
+            docker.before();
+            assertThat(docker.hostNetworkedPort(5432).getInternalPort(), is(5432));
+            assertThat(docker.hostNetworkedPort(5432).getExternalPort(), is(5432));
+        } finally {
+            docker.after();
+        }
     }
 }


### PR DESCRIPTION
This commit uses JUnit's assumptions to ignore the
HostNetworkedPortsIntegrationTest on any OS but linux.

Ports exposed on the "host" network are accessible on linux because the host
is running on localhost. On Windows and Mac, the host is instead running on a
linux VM and the ports are not accessible.