### PR TITLE
Delete containers left over from an integration test.

### DIFF
--- a/docker-compose-rule-junit4/src/test/java/com/palantir/docker/compose/RemoveConflictingContainersIntegrationTest.java
+++ b/docker-compose-rule-junit4/src/test/java/com/palantir/docker/compose/RemoveConflictingContainersIntegrationTest.java
@@ -36,18 +36,20 @@ public class RemoveConflictingContainersIntegrationTest {
                 .file(DOCKER_COMPOSE_YAML_PATH)
                 .retryAttempts(0)
                 .build();
-        composition.before();
-
         DockerComposeRule conflictingComposition = DockerComposeRule.builder()
                 .file(DOCKER_COMPOSE_YAML_PATH)
                 .retryAttempts(0)
                 .removeConflictingContainersOnStartup(false)
                 .build();
-
-        exception.expect(DockerExecutionException.class);
-        exception.expectMessage("'docker-compose up -d' returned exit code");
-
-        conflictingComposition.before();
+        try {
+            composition.before();
+            exception.expect(DockerExecutionException.class);
+            exception.expectMessage("'docker-compose up -d' returned exit code");
+            conflictingComposition.before();
+        } finally {
+            composition.after();
+            conflictingComposition.after();
+        }
     }
 
     @Test


### PR DESCRIPTION
This makes sure the containers created in
`RemoveConflictingContainersIntegrationTest` are deleted after each method.

The containers left over by this test can then make the test fail when it gets run again (since the test uses `removeConflictingContainersOnStartup(false)`). After this commit, doing a full build results in no containers being left over.