### PR TITLE
Increase timeout in ContainerIntegrationTests from 1s to 10s.

### DIFF
--- a/docker-compose-rule-core/src/test/java/com/palantir/docker/compose/connection/ContainerIntegrationTests.java
+++ b/docker-compose-rule-core/src/test/java/com/palantir/docker/compose/connection/ContainerIntegrationTests.java
@@ -26,7 +26,7 @@ import org.mockito.internal.matchers.GreaterOrEqual;
 
 public class ContainerIntegrationTests {
 
-    private static final ConditionFactory wait = await().atMost(1, TimeUnit.SECONDS);
+    private static final ConditionFactory wait = await().atMost(10, TimeUnit.SECONDS);
 
     private final DockerMachine dockerMachine = DockerMachine.localMachine().build();
     private final Docker docker = new Docker(DockerExecutable.builder()


### PR DESCRIPTION
This prevents the test from intermittently failing when the health status took
longer than 1s to be updated.