### PR TITLE
Handle error output of docker commands

### DIFF
--- a/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/execution/DefaultDockerCompose.java
+++ b/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/execution/DefaultDockerCompose.java
@@ -213,9 +213,9 @@ public class DefaultDockerCompose implements DockerCompose {
     }
 
     private static ErrorHandler swallowingDownCommandDoesNotExist() {
-        return (exitCode, output, commandName, commands) -> {
+        return (exitCode, output, error, commandName, commands) -> {
             if (downCommandWasPresent(output)) {
-                Command.throwingOnError().handle(exitCode, output, commandName, commands);
+                Command.throwingOnError().handle(exitCode, output, error, commandName, commands);
             }
 
             log.warn("It looks like `docker-compose down` didn't work.");

--- a/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/execution/DockerComposeExecutable.java
+++ b/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/execution/DockerComposeExecutable.java
@@ -59,7 +59,7 @@ public abstract class DockerComposeExecutable implements Executable {
                         .add(defaultDockerComposePath())
                         .add(commands)
                         .build();
-                return new ProcessBuilder(args).redirectErrorStream(true).start();
+                return new ProcessBuilder(args).redirectErrorStream(false).start();
             }
         }, log::trace);
 
@@ -97,7 +97,7 @@ public abstract class DockerComposeExecutable implements Executable {
 
         return dockerConfiguration().configuredDockerComposeProcess()
                 .command(args)
-                .redirectErrorStream(true)
+                .redirectErrorStream(false)
                 .start();
     }
 

--- a/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/execution/DockerExecutable.java
+++ b/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/execution/DockerExecutable.java
@@ -59,7 +59,7 @@ public abstract class DockerExecutable implements Executable {
 
         return dockerConfiguration().configuredDockerComposeProcess()
                 .command(args)
-                .redirectErrorStream(true)
+                .redirectErrorStream(false)
                 .start();
     }
 

--- a/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/execution/ErrorHandler.java
+++ b/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/execution/ErrorHandler.java
@@ -17,5 +17,5 @@ package com.palantir.docker.compose.execution;
 
 @FunctionalInterface
 public interface ErrorHandler {
-    void handle(int exitCode, String output, String commandName, String... commands);
+    void handle(int exitCode, String output, String error, String commandName, String... commands);
 }

--- a/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/execution/ProcessResult.java
+++ b/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/execution/ProcessResult.java
@@ -18,10 +18,18 @@ package com.palantir.docker.compose.execution;
 public class ProcessResult {
     private int exitCode;
     private final String output;
+    private final String error;
 
     public ProcessResult(int exitCode, String output) {
         this.exitCode = exitCode;
         this.output = output;
+        this.error = null;
+    }
+
+    public ProcessResult(int exitCode, String output, String error) {
+        this.exitCode = exitCode;
+        this.output = output;
+        this.error = error;
     }
 
     public int exitCode() {
@@ -30,5 +38,9 @@ public class ProcessResult {
 
     public String output() {
         return output;
+    }
+
+    public String error() {
+        return error;
     }
 }

--- a/docker-compose-rule-core/src/test/java/com/palantir/docker/compose/execution/CommandShould.java
+++ b/docker-compose-rule-core/src/test/java/com/palantir/docker/compose/execution/CommandShould.java
@@ -59,7 +59,7 @@ public class CommandShould {
         givenTheUnderlyingProcessTerminatesWithAnExitCodeOf(expectedExitCode);
         dockerComposeCommand.execute(errorHandler, "rm", "-f");
 
-        verify(errorHandler).handle(expectedExitCode, "", "docker-compose", "rm", "-f");
+        verify(errorHandler).handle(expectedExitCode, "", null, "docker-compose", "rm", "-f");
     }
 
     @Test public void


### PR DESCRIPTION
Rather than mix stdout and stderr of docker commands, I suggest a way to handle stderr separately.

See https://github.com/palantir/docker-compose-rule/issues/187