### PR TITLE
Update FileLogCollector.java

### DIFF
--- a/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/logging/FileLogCollector.java
+++ b/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/logging/FileLogCollector.java
@@ -86,6 +86,7 @@ public class FileLogCollector implements LogCollector {
             log.warn("docker containers were still running when log collection stopped");
             executor.shutdownNow();
         }
+        executor = null;
     }
 
 }


### PR DESCRIPTION
Fix executor of log collection not reinitialized. Fixes one of the issues outlined in the #122 .

Since 122 was closed without merge, I was hoping to get at least this portion of the fix in source.
Thanks @joelea who provided the fix first..