### PR TITLE
Add default exe locations for Windows

### DIFF
--- a/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/execution/DockerComposeExecutable.java
+++ b/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/execution/DockerComposeExecutable.java
@@ -32,7 +32,8 @@ public abstract class DockerComposeExecutable implements Executable {
     private static final DockerCommandLocations DOCKER_COMPOSE_LOCATIONS = new DockerCommandLocations(
             System.getenv("DOCKER_COMPOSE_LOCATION"),
             "/usr/local/bin/docker-compose",
-            "/usr/bin/docker-compose"
+            "/usr/bin/docker-compose",
+            "C:/program files/docker/docker/resources/bin/docker-compose.exe"
     );
 
     private static String defaultDockerComposePath() {

--- a/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/execution/DockerExecutable.java
+++ b/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/execution/DockerExecutable.java
@@ -29,7 +29,8 @@ public abstract class DockerExecutable implements Executable {
     private static final DockerCommandLocations DOCKER_LOCATIONS = new DockerCommandLocations(
             System.getenv("DOCKER_LOCATION"),
             "/usr/local/bin/docker",
-            "/usr/bin/docker"
+            "/usr/bin/docker",
+            "C:/program files/docker/docker/resources/bin/docker.exe"
     );
 
     @Value.Parameter protected abstract DockerConfiguration dockerConfiguration();


### PR DESCRIPTION
I added a default exe location for Windows so I don't have to always set the environment variable.  It'll be nice to work "out of the box" for windows users.