### PR TITLE
Better error message on container failing to listen to a port

### DIFF
--- a/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/connection/Container.java
+++ b/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/connection/Container.java
@@ -57,7 +57,7 @@ public class Container {
         try {
             DockerPort port = port(internalPort);
             if (!port.isListeningNow()) {
-                return SuccessOrFailure.failure(internalPort + " is not listening");
+                return SuccessOrFailure.failure("Internal port " + internalPort + " is not listening in container " + containerName);
             }
             return port.isHttpRespondingSuccessfully(urlFunction, andCheckStatus)
                     .mapFailure(failureMessage -> internalPort + " does not have a http response from " + urlFunction.apply(port) + ":\n" + failureMessage);

--- a/docker-compose-rule-junit4/src/test/java/com/palantir/docker/compose/HostNetworkedPortsIntegrationTest.java
+++ b/docker-compose-rule-junit4/src/test/java/com/palantir/docker/compose/HostNetworkedPortsIntegrationTest.java
@@ -28,7 +28,7 @@ import org.junit.Test;
 
 public class HostNetworkedPortsIntegrationTest {
     private static HealthCheck<DockerPort> toBeOpen() {
-        return port -> SuccessOrFailure.fromBoolean(port.isListeningNow(), "" + port + "was not listening");
+        return port -> SuccessOrFailure.fromBoolean(port.isListeningNow(), "Internal port " + port + " was not listening");
     }
 
     @Test public void


### PR DESCRIPTION
We recently had a mysterious failure that was hard to debug because we had two containers binding to the same port.