### PR TITLE
Convert ShutdownStrategy to enums

### DIFF
--- a/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/configuration/ShutdownFunction.java
+++ b/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/configuration/ShutdownFunction.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2018 Palantir Technologies, Inc. All rights reserved.
+ */
+
+package com.palantir.docker.compose.configuration;
+
+import com.palantir.docker.compose.execution.Docker;
+import com.palantir.docker.compose.execution.DockerCompose;
+import java.io.IOException;
+
+@FunctionalInterface
+public interface ShutdownFunction {
+
+    void shutdown(DockerCompose dockerCompose, Docker docker) throws IOException, InterruptedException;
+
+}

--- a/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/configuration/ShutdownStrategy.java
+++ b/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/configuration/ShutdownStrategy.java
@@ -4,57 +4,65 @@
 
 package com.palantir.docker.compose.configuration;
 
-import com.palantir.docker.compose.execution.AggressiveShutdownStrategy;
-import com.palantir.docker.compose.execution.AggressiveShutdownWithNetworkCleanupStrategy;
+import com.palantir.docker.compose.execution.AggressiveShutdownFunction;
+import com.palantir.docker.compose.execution.AggressiveShutdownWithNetworkCleanupFunction;
 import com.palantir.docker.compose.execution.Docker;
 import com.palantir.docker.compose.execution.DockerCompose;
-import com.palantir.docker.compose.execution.GracefulShutdownStrategy;
-import com.palantir.docker.compose.execution.KillDownShutdownStrategy;
-import com.palantir.docker.compose.execution.SkipShutdownStrategy;
+import com.palantir.docker.compose.execution.GracefulShutdownFunction;
+import com.palantir.docker.compose.execution.KillDownShutdownFunction;
+import com.palantir.docker.compose.execution.SkipShutdownFunction;
 import java.io.IOException;
 
 /**
  * How should a cluster of containers be shut down by the `after` method of
  * DockerComposeRule.
  */
-public interface ShutdownStrategy {
-
+public enum ShutdownStrategy implements ShutdownFunction {
     /**
      * Call rm on all containers, working around btrfs bug on CircleCI.
      *
      * @deprecated Use {@link #KILL_DOWN} (the default strategy)
      */
     @Deprecated
-    ShutdownStrategy AGGRESSIVE = new AggressiveShutdownStrategy();
+    AGGRESSIVE(new AggressiveShutdownFunction()),
     /**
      * Call rm on all containers, then call docker-compose down.
      *
      * @deprecated Use {@link #KILL_DOWN} (the default strategy)
      */
     @Deprecated
-    ShutdownStrategy AGGRESSIVE_WITH_NETWORK_CLEANUP = new AggressiveShutdownWithNetworkCleanupStrategy();
+    AGGRESSIVE_WITH_NETWORK_CLEANUP(new AggressiveShutdownWithNetworkCleanupFunction()),
     /**
      * Call docker-compose down, kill, then rm. Allows containers up to 10 seconds to shut down
      * gracefully.
-     *
+     * <p>
      * <p>With this strategy, you will need to take care not to accidentally write images
      * that ignore their down signal, for instance by putting their run command in as a
      * string (which is interpreted by a SIGTERM-ignoring bash) rather than an array of strings.
      */
-    ShutdownStrategy GRACEFUL = new GracefulShutdownStrategy();
+    GRACEFUL(new GracefulShutdownFunction()),
     /**
      * Call docker-compose kill then down.
      */
-    ShutdownStrategy KILL_DOWN = new KillDownShutdownStrategy();
+    KILL_DOWN(new KillDownShutdownFunction()),
     /**
      * Skip shutdown, leaving containers running after tests finish executing.
-     *
+     * <p>
      * <p>You can use this option to speed up repeated test execution locally by leaving
      * images up between runs. Do <b>not</b> commit it! You will be potentially abandoning
      * long-running processes and leaking resources on your CI platform!
      */
-    ShutdownStrategy SKIP = new SkipShutdownStrategy();
+    SKIP(new SkipShutdownFunction());
 
-    void shutdown(DockerCompose dockerCompose, Docker docker) throws IOException, InterruptedException;
+    private ShutdownFunction delegate;
+
+    ShutdownStrategy(ShutdownFunction delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public void shutdown(DockerCompose dockerCompose, Docker docker) throws IOException, InterruptedException {
+        delegate.shutdown(dockerCompose, docker);
+    }
 
 }

--- a/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/execution/AggressiveShutdownFunction.java
+++ b/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/execution/AggressiveShutdownFunction.java
@@ -6,6 +6,7 @@ package com.palantir.docker.compose.execution;
 
 import static java.util.stream.Collectors.toList;
 
+import com.palantir.docker.compose.configuration.ShutdownFunction;
 import com.palantir.docker.compose.configuration.ShutdownStrategy;
 import com.palantir.docker.compose.connection.ContainerName;
 import java.io.IOException;
@@ -20,9 +21,9 @@ import org.slf4j.LoggerFactory;
  * @deprecated Use {@link ShutdownStrategy#KILL_DOWN}
  */
 @Deprecated
-public class AggressiveShutdownStrategy implements ShutdownStrategy {
+public class AggressiveShutdownFunction implements ShutdownFunction {
 
-    private static final Logger log = LoggerFactory.getLogger(AggressiveShutdownStrategy.class);
+    private static final Logger log = LoggerFactory.getLogger(AggressiveShutdownFunction.class);
 
     @Override
     public void shutdown(DockerCompose dockerCompose, Docker docker) throws IOException, InterruptedException {

--- a/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/execution/AggressiveShutdownWithNetworkCleanupFunction.java
+++ b/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/execution/AggressiveShutdownWithNetworkCleanupFunction.java
@@ -6,6 +6,7 @@ package com.palantir.docker.compose.execution;
 
 import static java.util.stream.Collectors.toList;
 
+import com.palantir.docker.compose.configuration.ShutdownFunction;
 import com.palantir.docker.compose.configuration.ShutdownStrategy;
 import com.palantir.docker.compose.connection.ContainerName;
 import java.io.IOException;
@@ -19,9 +20,9 @@ import org.slf4j.LoggerFactory;
  * @deprecated Use {@link ShutdownStrategy#KILL_DOWN}
  */
 @Deprecated
-public class AggressiveShutdownWithNetworkCleanupStrategy implements ShutdownStrategy {
+public class AggressiveShutdownWithNetworkCleanupFunction implements ShutdownFunction {
 
-    private static final Logger log = LoggerFactory.getLogger(AggressiveShutdownWithNetworkCleanupStrategy.class);
+    private static final Logger log = LoggerFactory.getLogger(AggressiveShutdownWithNetworkCleanupFunction.class);
 
     @Override
     public void shutdown(DockerCompose dockerCompose, Docker docker) throws IOException, InterruptedException {

--- a/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/execution/GracefulShutdownFunction.java
+++ b/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/execution/GracefulShutdownFunction.java
@@ -4,7 +4,7 @@
 
 package com.palantir.docker.compose.execution;
 
-import com.palantir.docker.compose.configuration.ShutdownStrategy;
+import com.palantir.docker.compose.configuration.ShutdownFunction;
 import java.io.IOException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -13,9 +13,9 @@ import org.slf4j.LoggerFactory;
  * Send SIGTERM to containers first, allowing them up to 10 seconds to
  * terminate before killing and rm-ing them.
  */
-public class GracefulShutdownStrategy implements ShutdownStrategy {
+public class GracefulShutdownFunction implements ShutdownFunction {
 
-    private static final Logger log = LoggerFactory.getLogger(GracefulShutdownStrategy.class);
+    private static final Logger log = LoggerFactory.getLogger(GracefulShutdownFunction.class);
 
     @Override
     public void shutdown(DockerCompose dockerCompose, Docker docker) throws IOException, InterruptedException {

--- a/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/execution/KillDownShutdownFunction.java
+++ b/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/execution/KillDownShutdownFunction.java
@@ -4,7 +4,7 @@
 
 package com.palantir.docker.compose.execution;
 
-import com.palantir.docker.compose.configuration.ShutdownStrategy;
+import com.palantir.docker.compose.configuration.ShutdownFunction;
 import java.io.IOException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -16,9 +16,9 @@ import org.slf4j.LoggerFactory;
  * many Docker images simply ignore due to being run by bash as process 1. We don't need a graceful
  * shutdown period anyway since the tests are done and we're destroying the docker image.
  */
-public class KillDownShutdownStrategy implements ShutdownStrategy {
+public class KillDownShutdownFunction implements ShutdownFunction {
 
-    private static final Logger log = LoggerFactory.getLogger(KillDownShutdownStrategy.class);
+    private static final Logger log = LoggerFactory.getLogger(KillDownShutdownFunction.class);
 
     @Override
     public void shutdown(DockerCompose dockerCompose, Docker docker)

--- a/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/execution/SkipShutdownFunction.java
+++ b/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/execution/SkipShutdownFunction.java
@@ -4,13 +4,13 @@
 
 package com.palantir.docker.compose.execution;
 
-import com.palantir.docker.compose.configuration.ShutdownStrategy;
+import com.palantir.docker.compose.configuration.ShutdownFunction;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class SkipShutdownStrategy implements ShutdownStrategy {
+public class SkipShutdownFunction implements ShutdownFunction {
 
-    private static final Logger log = LoggerFactory.getLogger(SkipShutdownStrategy.class);
+    private static final Logger log = LoggerFactory.getLogger(SkipShutdownFunction.class);
 
     @Override
     public void shutdown(DockerCompose dockerCompose, Docker docker) {
@@ -22,6 +22,5 @@ public class SkipShutdownStrategy implements ShutdownStrategy {
                 + "* long running processes and leaking resources.                                          *\n"
                 + "******************************************************************************************");
     }
-
 
 }

--- a/docker-compose-rule-junit4/src/main/java/com/palantir/docker/compose/DockerComposeRule.java
+++ b/docker-compose-rule-junit4/src/main/java/com/palantir/docker/compose/DockerComposeRule.java
@@ -8,6 +8,7 @@ import static com.palantir.docker.compose.connection.waiting.ClusterHealthCheck.
 
 import com.palantir.docker.compose.configuration.DockerComposeFiles;
 import com.palantir.docker.compose.configuration.ProjectName;
+import com.palantir.docker.compose.configuration.ShutdownFunction;
 import com.palantir.docker.compose.configuration.ShutdownStrategy;
 import com.palantir.docker.compose.connection.Cluster;
 import com.palantir.docker.compose.connection.Container;
@@ -90,7 +91,7 @@ public abstract class DockerComposeRule extends ExternalResource {
     }
 
     @Value.Default
-    public ShutdownStrategy shutdownStrategy() {
+    public ShutdownFunction shutdownStrategy() {
         return ShutdownStrategy.KILL_DOWN;
     }
 

--- a/docker-compose-rule-junit4/src/test/java/com/palantir/docker/compose/DockerComposeRuleShould.java
+++ b/docker-compose-rule-junit4/src/test/java/com/palantir/docker/compose/DockerComposeRuleShould.java
@@ -36,7 +36,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.palantir.docker.compose.configuration.DockerComposeFiles;
 import com.palantir.docker.compose.configuration.MockDockerEnvironment;
-import com.palantir.docker.compose.configuration.ShutdownStrategy;
+import com.palantir.docker.compose.configuration.ShutdownFunction;
 import com.palantir.docker.compose.connection.Container;
 import com.palantir.docker.compose.connection.DockerMachine;
 import com.palantir.docker.compose.connection.DockerPort;
@@ -110,7 +110,7 @@ public class DockerComposeRuleShould {
 
     @Test
     public void calls_shutdownStrategy_in_after_method() throws IOException, InterruptedException {
-        ShutdownStrategy shutdownStrategy = mock(ShutdownStrategy.class);
+        ShutdownFunction shutdownStrategy = mock(ShutdownFunction.class);
         rule = DockerComposeRule.builder()
                 .dockerCompose(dockerCompose)
                 .files(mockFiles)


### PR DESCRIPTION
Switched to using an enum for ShutdownStrategy in order to allow use within annotations. This should allow the `ShutdownStrategy` to be provided as an enum config point to the annotation for the Junit5 implementation of DCR in #223 