### PR TITLE
Add feature to choose which services to start with docker-compose up

### DIFF
--- a/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/execution/DelegatingDockerCompose.java
+++ b/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/execution/DelegatingDockerCompose.java
@@ -113,6 +113,11 @@ abstract class DelegatingDockerCompose implements DockerCompose {
     }
 
     @Override
+    public List<String> servicesToStart() {
+        return dockerCompose.servicesToStart();
+    }
+
+    @Override
     public boolean writeLogs(String container, OutputStream output) throws IOException {
         return dockerCompose.writeLogs(container, output);
     }

--- a/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/execution/DockerCompose.java
+++ b/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/execution/DockerCompose.java
@@ -44,6 +44,7 @@ public interface DockerCompose {
     Optional<String> id(Container container) throws IOException, InterruptedException;
     String config() throws IOException, InterruptedException;
     List<String> services() throws IOException, InterruptedException;
+    List<String> servicesToStart();
     boolean writeLogs(String container, OutputStream output) throws IOException;
     Ports ports(String service) throws IOException, InterruptedException;
 }

--- a/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/logging/FileLogCollector.java
+++ b/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/logging/FileLogCollector.java
@@ -61,6 +61,13 @@ public class FileLogCollector implements LogCollector {
         if (serviceNames.size() == 0) {
             return;
         }
+
+        List<String> servicesToStart = dockerCompose.servicesToStart();
+        if (!servicesToStart.isEmpty()) {
+            // Services to start up are a subset of all services.
+            serviceNames = servicesToStart;
+        }
+
         executor = Executors.newFixedThreadPool(serviceNames.size());
         serviceNames.stream().forEachOrdered(service -> this.collectLogs(service, dockerCompose));
     }

--- a/docker-compose-rule-junit4/src/main/java/com/palantir/docker/compose/DockerComposeRule.java
+++ b/docker-compose-rule-junit4/src/main/java/com/palantir/docker/compose/DockerComposeRule.java
@@ -68,6 +68,15 @@ public abstract class DockerComposeRule extends ExternalResource {
         return ProjectName.random();
     }
 
+    /**
+     * The names of services to start, via {@code docker-compose up -d SERVICE...}.  If empty (the
+     * default), all services are started.  This can be a subset of the services defined in
+     * the Docker Compose files.
+     *
+     * @return the names of services to start
+     */
+    public abstract List<String> servicesToStart();
+
     @Value.Default
     public DockerComposeExecutable dockerComposeExecutable() {
         return DockerComposeExecutable.builder()
@@ -96,7 +105,7 @@ public abstract class DockerComposeRule extends ExternalResource {
 
     @Value.Default
     public DockerCompose dockerCompose() {
-        DockerCompose dockerCompose = new DefaultDockerCompose(dockerComposeExecutable(), machine());
+        DockerCompose dockerCompose = new DefaultDockerCompose(dockerComposeExecutable(), machine(), servicesToStart());
         return new RetryingDockerCompose(retryAttempts(), dockerCompose);
     }
 

--- a/docker-compose-rule-junit4/src/test/java/com/palantir/docker/compose/DockerComposeRulePartialServicesIntegrationTest.java
+++ b/docker-compose-rule-junit4/src/test/java/com/palantir/docker/compose/DockerComposeRulePartialServicesIntegrationTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.docker.compose;
+
+import static com.google.common.base.Throwables.propagate;
+import static com.palantir.docker.compose.connection.waiting.HealthChecks.toHaveAllPortsOpen;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+
+import com.google.common.collect.ImmutableList;
+import com.palantir.docker.compose.configuration.DockerComposeFiles;
+import com.palantir.docker.compose.connection.Container;
+import com.palantir.docker.compose.execution.DockerExecutionException;
+import java.io.IOException;
+import java.util.List;
+import java.util.function.Consumer;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class DockerComposeRulePartialServicesIntegrationTest {
+
+    private static final List<String> CONTAINERS = ImmutableList.of("db", "db2", "db3", "db4");
+
+    @Rule
+    public ExpectedException exception = ExpectedException.none();
+
+    @Rule
+    public final DockerComposeRule docker = DockerComposeRule.builder()
+            .files(DockerComposeFiles.from("src/test/resources/docker-compose.yaml"))
+            .addServicesToStart("db") // Only start the db container.
+            .waitingForService("db", toHaveAllPortsOpen())
+            .build();
+
+    // Not a @Rule so that we can call before() and handle the exception.
+    // db5 is a nonexistent service in docker-compose.yaml.
+    private final DockerComposeRule invalidDocker = DockerComposeRule.builder()
+            .files(DockerComposeFiles.from("src/test/resources/docker-compose.yaml"))
+            .addServicesToStart("db5") // Only start the db container.
+            .waitingForService("db5", toHaveAllPortsOpen())
+            .build();
+
+    private static void forEachContainer(Consumer<String> consumer) {
+        CONTAINERS.forEach(consumer);
+    }
+
+    @Test
+    public void should_run_docker_compose_up_for_db_container_only() {
+        forEachContainer(containerName -> {
+            Container container = docker.containers().container(containerName);
+            try {
+                if ("db".equals(containerName)) {
+                    assertThat(container.state().isUp(), is(true));
+                    assertThat(container.port(5432).isListeningNow(), is(true));
+                } else {
+                    assertThat(container.state().isUp(), is(false));
+                }
+            } catch (IOException | InterruptedException e) {
+                propagate(e);
+            }
+        });
+    }
+
+    @Test
+    public void after_test_is_executed_the_launched_db_container_is_no_longer_listening() {
+        docker.after();
+
+        forEachContainer(containerName -> {
+            Container container = docker.containers().container(containerName);
+            try {
+                assertThat(container.state().isUp(), is(false));
+                if ("db".equals(containerName)) {
+                    assertThat(container.port(5432).isListeningNow(), is(false));
+                }
+            } catch (IOException | InterruptedException e) {
+                propagate(e);
+            }
+        });
+    }
+
+    @Test
+    public void should_run_docker_compose_up_for_nonexistent_container() throws IOException, InterruptedException {
+        exception.expect(DockerExecutionException.class);
+        exception.expectMessage("No such service: db5");
+
+        invalidDocker.before();
+    }
+}


### PR DESCRIPTION
Sometimes we prefer to run `docker-compose up -d service1 service2 ...` where this represents a proper subset of services.  It helps reduce startup time, and allows for better reuse of Docker Compose files.

These changes add to the `DockerComposeRule` builder to specify which services to start, e.g.

```
.addServicesToStart("db") // Only start the db container.
```

See also: https://github.com/palantir/docker-compose-rule/issues/182