### PR TITLE
Fixed issue with memoized ports upon (re)start of docker container

### DIFF
--- a/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/connection/Container.java
+++ b/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/connection/Container.java
@@ -33,7 +33,7 @@ public class Container {
     private final Docker docker;
     private final DockerCompose dockerCompose;
 
-    private final Supplier<Ports> portMappings = Suppliers.memoize(this::getDockerPorts);
+    private Supplier<Ports> portMappings = Suppliers.memoize(this::getDockerPorts);
 
     public Container(String containerName, Docker docker, DockerCompose dockerCompose) {
         this.containerName = containerName;
@@ -92,6 +92,7 @@ public class Container {
 
     public void start() throws IOException, InterruptedException {
         dockerCompose.start(this);
+        portMappings = Suppliers.memoize(this::getDockerPorts);
     }
 
     public void stop() throws IOException, InterruptedException {

--- a/docker-compose-rule-core/src/test/java/com/palantir/docker/compose/configuration/MockDockerEnvironment.java
+++ b/docker-compose-rule-core/src/test/java/com/palantir/docker/compose/configuration/MockDockerEnvironment.java
@@ -30,8 +30,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
-import org.mockito.invocation.InvocationOnMock;
-import org.mockito.stubbing.Answer;
 
 public class MockDockerEnvironment {
 

--- a/docker-compose-rule-core/src/test/java/com/palantir/docker/compose/configuration/MockDockerEnvironment.java
+++ b/docker-compose-rule-core/src/test/java/com/palantir/docker/compose/configuration/MockDockerEnvironment.java
@@ -28,7 +28,10 @@ import com.palantir.docker.compose.execution.DockerCompose;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
 
 public class MockDockerEnvironment {
 
@@ -67,6 +70,14 @@ public class MockDockerEnvironment {
         DockerPort port = dockerPortSpy(ip, externalPortNumber, internalPortNumber);
         when(dockerComposeProcess.ports(service)).thenReturn(new Ports(port));
         return port;
+    }
+
+    public void ephemeralPort(String service, String ip, int internalPortNumber) throws IOException, InterruptedException {
+        AtomicInteger currentExternalPort = new AtomicInteger(33700);
+        when(dockerComposeProcess.ports(service)).then(a -> {
+            DockerPort port = dockerPortSpy(ip, currentExternalPort.incrementAndGet(), internalPortNumber);
+            return new Ports(port);
+        });
     }
 
     public void ports(String service, String ip, Integer... portNumbers) throws IOException, InterruptedException {


### PR DESCRIPTION
Port mappings can be different after restarting a docker container, i.e. when it's services uses ports in the ephemeral range. This means that the mapping needs to be re-evaluated upon (re)start of the container.