### PR TITLE
Collect all logs of restarted containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ public class DockerComposeRuleTest {
 }
 ```
 
-This will automatically record logs for all containers in real time to the specified directory. Collection will stop when the containers terminate.
+This will collect logs for all containers. Collection will occur when after the tests are finished executing.
 
 The `LogDirectory` class contains utility methods to generate these paths.  For example, you can write logs directly into the `$CIRCLE_ARTIFACTS` directory on CI (but fall back to `build/dockerLogs` locally) using:
 

--- a/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/execution/DefaultDockerCompose.java
+++ b/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/execution/DefaultDockerCompose.java
@@ -198,7 +198,7 @@ public class DefaultDockerCompose implements DockerCompose {
                     .pollInterval(50, TimeUnit.MILLISECONDS)
                     .atMost(LOG_WAIT_TIMEOUT.getMillis(), TimeUnit.MILLISECONDS)
                     .until(() -> exists(container));
-            Process executedProcess = followLogs(container);
+            Process executedProcess = logs(container);
             IOUtils.copy(executedProcess.getInputStream(), output);
             executedProcess.waitFor(COMMAND_TIMEOUT.getMillis(), MILLISECONDS);
         } catch (InterruptedException e) {
@@ -219,11 +219,7 @@ public class DefaultDockerCompose implements DockerCompose {
         return Optional.of(id);
     }
 
-    private Process followLogs(String container) throws IOException, InterruptedException {
-        if (version().greaterThanOrEqualTo(VERSION_1_7_0)) {
-            return rawExecutable.execute("logs", "--no-color", "--follow", container);
-        }
-
+    private Process logs(String container) throws IOException {
         return rawExecutable.execute("logs", "--no-color", container);
     }
 

--- a/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/logging/DoNothingLogCollector.java
+++ b/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/logging/DoNothingLogCollector.java
@@ -20,13 +20,7 @@ import com.palantir.docker.compose.execution.DockerCompose;
 public class DoNothingLogCollector implements LogCollector {
 
     @Override
-    public void startCollecting(DockerCompose dockerCompose) {
+    public void collectLogs(DockerCompose dockerCompose) {
 
     }
-
-    @Override
-    public void stopCollecting() {
-
-    }
-
 }

--- a/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/logging/LogCollector.java
+++ b/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/logging/LogCollector.java
@@ -20,8 +20,6 @@ import java.io.IOException;
 
 public interface LogCollector {
 
-    void startCollecting(DockerCompose dockerCompose) throws IOException, InterruptedException;
-
-    void stopCollecting() throws InterruptedException;
+    void collectLogs(DockerCompose dockerCompose) throws IOException, InterruptedException;
 
 }

--- a/docker-compose-rule-core/src/test/java/com/palantir/docker/compose/execution/DockerComposeShould.java
+++ b/docker-compose-rule-core/src/test/java/com/palantir/docker/compose/execution/DockerComposeShould.java
@@ -101,7 +101,6 @@ public class DockerComposeShould {
     public void call_docker_compose_with_no_colour_flag_on_logs() throws IOException {
         when(executedProcess.getInputStream()).thenReturn(
                 toInputStream("id"),
-                toInputStream("docker-compose version 1.5.6, build 1ad8866"),
                 toInputStream("logs"));
         ByteArrayOutputStream output = new ByteArrayOutputStream();
 
@@ -138,11 +137,10 @@ public class DockerComposeShould {
             throws IOException {
         when(executedProcess.getInputStream()).thenReturn(
                 toInputStream("id"),
-                toInputStream("docker-compose version 1.7.0, build 1ad8866"),
                 toInputStream("logs"));
         ByteArrayOutputStream output = new ByteArrayOutputStream();
         compose.writeLogs("db", output);
-        verify(executor).execute("logs", "--no-color", "--follow", "db");
+        verify(executor).execute("logs", "--no-color", "db");
         assertThat(new String(output.toByteArray(), StandardCharsets.UTF_8), is("logs"));
     }
 

--- a/docker-compose-rule-junit4/src/main/java/com/palantir/docker/compose/DockerComposeRule.java
+++ b/docker-compose-rule-junit4/src/main/java/com/palantir/docker/compose/DockerComposeRule.java
@@ -148,7 +148,6 @@ public abstract class DockerComposeRule extends ExternalResource {
         }
         upDockerCompose.up();
 
-        logCollector().startCollecting(dockerCompose());
         log.debug("Waiting for services");
         new ClusterWait(ClusterHealthCheck.nativeHealthChecks(), nativeServiceHealthCheckTimeout())
                 .waitUntilReady(containers());
@@ -159,8 +158,8 @@ public abstract class DockerComposeRule extends ExternalResource {
     @Override
     public void after() {
         try {
-            shutdownStrategy().shutdown(this.dockerCompose(), this.docker());
-            logCollector().stopCollecting();
+            shutdownStrategy().shutdown(dockerCompose(), docker());
+            logCollector().collectLogs(dockerCompose());
         } catch (IOException | InterruptedException e) {
             throw new RuntimeException("Error cleaning up docker compose cluster", e);
         }

--- a/docker-compose-rule-junit4/src/test/java/com/palantir/docker/compose/DockerComposeRuleShould.java
+++ b/docker-compose-rule-junit4/src/test/java/com/palantir/docker/compose/DockerComposeRuleShould.java
@@ -250,7 +250,7 @@ public class DockerComposeRuleShould {
     }
 
     @Test
-    public void not_shut_down_when_skipShutdown_is_true() throws InterruptedException {
+    public void not_shut_down_when_skipShutdown_is_true() throws IOException, InterruptedException {
         DockerComposeRule.builder()
                 .dockerCompose(dockerCompose)
                 .files(mockFiles)
@@ -260,7 +260,7 @@ public class DockerComposeRuleShould {
                 .build()
                 .after();
         verifyNoMoreInteractions(dockerCompose);
-        verify(logCollector, times(1)).stopCollecting();
+        verify(logCollector, times(1)).collectLogs(dockerCompose);
     }
 
     @Test


### PR DESCRIPTION
Fixes #172 

This has the side effect of not collecting logs until the tests are finished running. But this seems acceptable given the use cases of this rule.