### PR TITLE
Use computeIfAbsent to avoid creating unused objects

### DIFF
--- a/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/connection/ContainerCache.java
+++ b/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/connection/ContainerCache.java
@@ -36,7 +36,7 @@ public class ContainerCache {
     }
 
     public Container container(String containerName) {
-        containers.putIfAbsent(containerName, new Container(containerName, docker, dockerCompose));
+        containers.computeIfAbsent(containerName, name -> new Container(name, docker, dockerCompose));
         return containers.get(containerName);
     }
 


### PR DESCRIPTION
Small optimization using `computeIfAbsent`