### PR TITLE
Added network pruning to all shutdown strategies 

### DIFF
--- a/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/execution/AggressiveShutdownStrategy.java
+++ b/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/execution/AggressiveShutdownStrategy.java
@@ -40,6 +40,9 @@ public class AggressiveShutdownStrategy implements ShutdownStrategy {
 
         log.warn("Couldn't shut down containers due to btrfs volume error, "
                 + "see https://circleci.com/docs/docker-btrfs-error/ for more info.");
+
+        log.info("Pruning networks");
+        docker.pruneNetworks();
     }
 
     private static boolean removeContainersCatchingErrors(Docker docker, List<ContainerName> runningContainers) throws IOException, InterruptedException {

--- a/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/execution/AggressiveShutdownWithNetworkCleanupStrategy.java
+++ b/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/execution/AggressiveShutdownWithNetworkCleanupStrategy.java
@@ -29,7 +29,8 @@ public class AggressiveShutdownWithNetworkCleanupStrategy implements ShutdownStr
 
         log.info("Shutting down {}", runningContainers.stream().map(ContainerName::semanticName).collect(toList()));
         removeContainersCatchingErrors(docker, runningContainers);
-        removeNetworks(dockerCompose);
+        removeNetworks(dockerCompose, docker);
+
     }
 
     private static void removeContainersCatchingErrors(Docker docker, List<ContainerName> runningContainers) throws IOException, InterruptedException {
@@ -49,7 +50,8 @@ public class AggressiveShutdownWithNetworkCleanupStrategy implements ShutdownStr
         log.debug("Finished shutdown");
     }
 
-    private static void removeNetworks(DockerCompose dockerCompose) throws IOException, InterruptedException {
+    private static void removeNetworks(DockerCompose dockerCompose, Docker docker) throws IOException, InterruptedException {
         dockerCompose.down();
+        docker.pruneNetworks();
     }
 }

--- a/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/execution/Docker.java
+++ b/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/execution/Docker.java
@@ -84,4 +84,8 @@ public class Docker {
     public String listNetworks() throws IOException, InterruptedException {
         return command.execute(Command.throwingOnError(), "network", "ls");
     }
+
+    public String pruneNetworks() throws IOException, InterruptedException {
+        return command.execute(Command.throwingOnError(), "network", "prune", "--force");
+    }
 }

--- a/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/execution/GracefulShutdownStrategy.java
+++ b/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/execution/GracefulShutdownStrategy.java
@@ -23,6 +23,7 @@ public class GracefulShutdownStrategy implements ShutdownStrategy {
         dockerCompose.down();
         dockerCompose.kill();
         dockerCompose.rm();
+        docker.pruneNetworks();
     }
 
 }

--- a/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/execution/KillDownShutdownStrategy.java
+++ b/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/execution/KillDownShutdownStrategy.java
@@ -28,5 +28,7 @@ public class KillDownShutdownStrategy implements ShutdownStrategy {
         log.debug("Downing docker-compose cluster");
         dockerCompose.down();
         log.debug("docker-compose cluster killed");
+        docker.pruneNetworks();
+        log.debug("Networks pruned");
     }
 }

--- a/docker-compose-rule-core/src/test/java/com/palantir/docker/compose/execution/DockerShould.java
+++ b/docker-compose-rule-core/src/test/java/com/palantir/docker/compose/execution/DockerShould.java
@@ -61,6 +61,16 @@ public class DockerShould {
     }
 
     @Test
+    public void call_docker_network_prune() throws IOException, InterruptedException {
+        String lsOutput = "0.0.0.0:7000->7000/tcp";
+        when(executedProcess.getInputStream()).thenReturn(toInputStream(lsOutput));
+
+        assertThat(docker.pruneNetworks(), is(lsOutput));
+
+        verify(executor).execute("network", "prune", "--force");
+    }
+
+    @Test
     public void understand_old_version_format() throws IOException, InterruptedException {
         when(executedProcess.getInputStream()).thenReturn(toInputStream("Docker version 1.7.2"));
 

--- a/docker-compose-rule-core/src/test/java/com/palantir/docker/compose/execution/GracefulShutdownStrategyShould.java
+++ b/docker-compose-rule-core/src/test/java/com/palantir/docker/compose/execution/GracefulShutdownStrategyShould.java
@@ -20,7 +20,7 @@ public class GracefulShutdownStrategyShould {
 
         ShutdownStrategy.GRACEFUL.shutdown(dockerCompose, docker);
 
-        InOrder inOrder = inOrder(dockerCompose);
+        InOrder inOrder = inOrder(dockerCompose, docker);
         inOrder.verify(dockerCompose).down();
         inOrder.verify(dockerCompose).kill();
         inOrder.verify(dockerCompose).rm();

--- a/docker-compose-rule-core/src/test/java/com/palantir/docker/compose/execution/GracefulShutdownStrategyShould.java
+++ b/docker-compose-rule-core/src/test/java/com/palantir/docker/compose/execution/GracefulShutdownStrategyShould.java
@@ -24,6 +24,7 @@ public class GracefulShutdownStrategyShould {
         inOrder.verify(dockerCompose).down();
         inOrder.verify(dockerCompose).kill();
         inOrder.verify(dockerCompose).rm();
+        inOrder.verify(docker).pruneNetworks();
         inOrder.verifyNoMoreInteractions();
     }
 }

--- a/docker-compose-rule-core/src/test/java/com/palantir/docker/compose/execution/KillDownShutdownStrategyShould.java
+++ b/docker-compose-rule-core/src/test/java/com/palantir/docker/compose/execution/KillDownShutdownStrategyShould.java
@@ -23,6 +23,7 @@ public class KillDownShutdownStrategyShould {
         InOrder inOrder = inOrder(dockerCompose);
         inOrder.verify(dockerCompose).kill();
         inOrder.verify(dockerCompose).down();
+        inOrder.verify(docker).pruneNetworks();
         inOrder.verifyNoMoreInteractions();
     }
 }

--- a/docker-compose-rule-core/src/test/java/com/palantir/docker/compose/execution/KillDownShutdownStrategyShould.java
+++ b/docker-compose-rule-core/src/test/java/com/palantir/docker/compose/execution/KillDownShutdownStrategyShould.java
@@ -20,7 +20,7 @@ public class KillDownShutdownStrategyShould {
 
         ShutdownStrategy.KILL_DOWN.shutdown(dockerCompose, docker);
 
-        InOrder inOrder = inOrder(dockerCompose);
+        InOrder inOrder = inOrder(dockerCompose, docker);
         inOrder.verify(dockerCompose).kill();
         inOrder.verify(dockerCompose).down();
         inOrder.verify(docker).pruneNetworks();


### PR DESCRIPTION
This is a harmless operation, [only removing networks not in use](https://docs.docker.com/engine/reference/commandline/network_prune/#extended-description)
_"Remove all unused networks. Unused networks are those which are not referenced by any containers."_

There is also however an argument for doing a [system prune](https://docs.docker.com/engine/reference/commandline/system_prune). What are your thoughts @iamdanfox ?
On one hand this will require re-downloading of images **every single time** but on the other it's a good way of guaranteeing a truly stateless setup? :) 