### PR TITLE
Increase timeout and simplify log collection

### DIFF
--- a/changelog/@unreleased/pr-299.v2.yml
+++ b/changelog/@unreleased/pr-299.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Log collection timeout has been increased to ensure that logs are successfully
+    collected.
+  links:
+  - https://github.com/palantir/docker-compose-rule/pull/299

--- a/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/execution/DefaultDockerCompose.java
+++ b/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/execution/DefaultDockerCompose.java
@@ -195,14 +195,15 @@ public class DefaultDockerCompose implements DockerCompose {
         try {
             Process executedProcess = logs(container);
             IOUtils.copy(executedProcess.getInputStream(), output);
-            boolean processExecuted = executedProcess.waitFor(LOG_TIMEOUT.getMillis(), TimeUnit.MILLISECONDS);
-            if (!processExecuted) {
+            boolean processFinished = executedProcess.waitFor(LOG_TIMEOUT.getMillis(), TimeUnit.MILLISECONDS);
+            boolean timedOut = !processFinished;
+            if (timedOut) {
                 log.error("Log collection timed out after {} millis. Destroying log reading process for container {}",
                         LOG_TIMEOUT.getMillis(),
                         container);
                 executedProcess.destroyForcibly();
             }
-            return processExecuted;
+            return processFinished;
         } catch (InterruptedException e) {
             return false;
         }

--- a/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/execution/DefaultDockerCompose.java
+++ b/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/execution/DefaultDockerCompose.java
@@ -33,6 +33,7 @@ import java.io.OutputStream;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 import org.apache.commons.io.IOUtils;
 import org.joda.time.Duration;
 import org.slf4j.Logger;
@@ -41,7 +42,7 @@ import org.slf4j.LoggerFactory;
 public class DefaultDockerCompose implements DockerCompose {
 
     public static final Version VERSION_1_7_0 = Version.valueOf("1.7.0");
-    private static final Duration LOG_WAIT_TIMEOUT = standardMinutes(30);
+    private static final Duration LOG_TIMEOUT = standardMinutes(1);
     private static final Logger log = LoggerFactory.getLogger(DefaultDockerCompose.class);
 
     private final Command command;
@@ -194,15 +195,10 @@ public class DefaultDockerCompose implements DockerCompose {
         try {
             Process executedProcess = logs(container);
             IOUtils.copy(executedProcess.getInputStream(), output);
-            executedProcess.waitFor();
-            return true;
+            return executedProcess.waitFor(LOG_TIMEOUT.getMillis(), TimeUnit.MILLISECONDS);
         } catch (InterruptedException e) {
             return false;
         }
-    }
-
-    private boolean exists(final String containerName) throws IOException, InterruptedException {
-        return id(containerName).orElse(null) != null;
     }
 
     private Optional<String> id(String containerName) throws IOException, InterruptedException {

--- a/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/logging/FileLogCollector.java
+++ b/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/logging/FileLogCollector.java
@@ -23,10 +23,6 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
-import java.util.List;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
 import org.apache.commons.lang3.Validate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -35,11 +31,7 @@ public class FileLogCollector implements LogCollector {
 
     private static final Logger log = LoggerFactory.getLogger(FileLogCollector.class);
 
-    private static final long STOP_TIMEOUT_IN_MILLIS = 50;
-
     private final File logDirectory;
-
-    private ExecutorService executor = null;
 
     public FileLogCollector(File logDirectory) {
         checkArgument(!logDirectory.isFile(), "Log directory cannot be a file");
@@ -55,40 +47,31 @@ public class FileLogCollector implements LogCollector {
 
     @Override
     public void collectLogs(DockerCompose dockerCompose) throws IOException, InterruptedException {
-        if (executor != null) {
-            throw new RuntimeException("Cannot start collecting the same logs twice");
-        }
-
-        List<String> serviceNames = dockerCompose.services();
-        if (serviceNames.size() == 0) {
-            return;
-        }
-        executor = Executors.newFixedThreadPool(serviceNames.size());
-        serviceNames.stream().forEachOrdered(service -> this.collectLogs(service, dockerCompose));
-
-        executor.shutdown();
-        if (!executor.awaitTermination(STOP_TIMEOUT_IN_MILLIS, TimeUnit.MILLISECONDS)) {
-            log.warn("docker containers were still running when log collection stopped");
-            executor.shutdownNow();
+        for (String service : dockerCompose.services()) {
+            try {
+                collectLogs(service, dockerCompose);
+            } catch (RuntimeException e) {
+                log.error("Failed to collect logs for '{}'", service);
+            }
         }
     }
 
     private void collectLogs(String container, DockerCompose dockerCompose) {
-        executor.submit(() -> {
-            File outputFile = new File(logDirectory, container + ".log");
-            try {
-                Files.createFile(outputFile.toPath());
-            } catch (final FileAlreadyExistsException e) {
-                // ignore
-            } catch (final IOException e) {
-                throw new RuntimeException("Error creating log file", e);
+        File outputFile = new File(logDirectory, container + ".log");
+        try {
+            Files.createFile(outputFile.toPath());
+        } catch (final FileAlreadyExistsException e) {
+            // ignore
+        } catch (final IOException e) {
+            throw new RuntimeException("Error creating log file", e);
+        }
+        log.info("Writing logs for container '{}' to '{}'", container, outputFile.getAbsolutePath());
+        try (FileOutputStream outputStream = new FileOutputStream(outputFile)) {
+            if (!dockerCompose.writeLogs(container, outputStream)) {
+                log.error("Timed out while collecting logs for '{}'", container);
             }
-            log.info("Writing logs for container '{}' to '{}'", container, outputFile.getAbsolutePath());
-            try (FileOutputStream outputStream = new FileOutputStream(outputFile)) {
-                dockerCompose.writeLogs(container, outputStream);
-            } catch (IOException e) {
-                throw new RuntimeException("Error reading log", e);
-            }
-        });
+        } catch (IOException e) {
+            throw new RuntimeException("Error reading log", e);
+        }
     }
 }

--- a/docker-compose-rule-core/src/test/java/com/palantir/docker/compose/logging/FileLogCollectorShould.java
+++ b/docker-compose-rule-core/src/test/java/com/palantir/docker/compose/logging/FileLogCollectorShould.java
@@ -138,16 +138,6 @@ public class FileLogCollectorShould {
         assertThat(new File(logDirectory, "db2.log"), is(fileContainingString("other")));
     }
 
-    @Test
-    public void throw_exception_when_trying_to_start_a_started_collector_a_second_time()
-            throws IOException, InterruptedException {
-        when(compose.services()).thenReturn(ImmutableList.of("db"));
-        logCollector.collectLogs(compose);
-        exception.expect(RuntimeException.class);
-        exception.expectMessage("Cannot start collecting the same logs twice");
-        logCollector.collectLogs(compose);
-    }
-
     private static File cannotBeCreatedDirectory() {
         File cannotBeCreatedDirectory = mock(File.class);
         when(cannotBeCreatedDirectory.isFile()).thenReturn(false);


### PR DESCRIPTION
## Before this PR
#293 broke log collection because the we time out the log collection after 50ms. This made sense when we were streaming logs but not after we changed the behavior to collect at the end.

## After this PR
We now give the logs process 1 minute to collect logs before timing out.
