### PR TITLE
[break] Turn on overshadowImplementation for builders

### DIFF
--- a/changelog/@unreleased/pr-301.v2.yml
+++ b/changelog/@unreleased/pr-301.v2.yml
@@ -1,0 +1,8 @@
+type: break
+break:
+  description: '`overshadowImplementation` is enabled for all docker-compose-rule
+    builders. Any uses of `ImmutableDockerComposeRule` as returned from `DockerComposeRule.builder()`
+    will now no longer compile. To fix, please use `DockerComposeRule` instead of
+    `ImmutableDockerComposeRule`.'
+  links:
+  - https://github.com/palantir/docker-compose-rule/pull/301

--- a/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/CustomImmutablesStyle.java
+++ b/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/CustomImmutablesStyle.java
@@ -20,5 +20,5 @@ import java.lang.annotation.Target;
 import org.immutables.value.Value.Style;
 
 @Target({ElementType.PACKAGE, ElementType.TYPE})
-@Style(depluralize = true, strictBuilder = true)
+@Style(depluralize = true, strictBuilder = true, overshadowImplementation = true)
 @interface CustomImmutablesStyle {}

--- a/docker-compose-rule-junit4/src/main/java/com/palantir/docker/compose/DockerComposeRule.java
+++ b/docker-compose-rule-junit4/src/main/java/com/palantir/docker/compose/DockerComposeRule.java
@@ -260,6 +260,11 @@ public abstract class DockerComposeRule extends ExternalResource {
         public Builder clusterWaits(Iterable<? extends ClusterWait> elements) {
             return addAllClusterWaits(elements);
         }
+
+        @Override
+        public DockerComposeRule build() {
+            return super.build();
+        }
     }
 
 }

--- a/docker-compose-rule-junit4/src/test/java/com/palantir/docker/compose/DockerComposeRuleShould.java
+++ b/docker-compose-rule-junit4/src/test/java/com/palantir/docker/compose/DockerComposeRuleShould.java
@@ -90,7 +90,7 @@ public class DockerComposeRuleShould {
     private DockerComposeFiles mockFiles = mock(DockerComposeFiles.class);
     private DockerMachine machine = mock(DockerMachine.class);
     private LogCollector logCollector = mock(LogCollector.class);
-    private ImmutableDockerComposeRule rule;
+    private DockerComposeRule rule;
 
     @Before public void
     setup() {


### PR DESCRIPTION
## Before this PR
`DockerComposeRule.builder()` returns a final `ImmutableDockerComposeRule` rather than a `DockerComposeRule`. This prevents us from transparently wrapping `DockerComposeRule` internally to record metrics from it.

## After this PR
==COMMIT_MSG==
`overshadowImplementation` is enabled for all docker-compose-rule builders. Any uses of `ImmutableDockerComposeRule` as returned from `DockerComposeRule.builder()` will now no longer compile. To fix, please use `DockerComposeRule` instead of `ImmutableDockerComposeRule`.
==COMMIT_MSG==

## Possible downsides?
Some peoples (<5 projects) code will break: https://github.com/search?q=ImmutableDockerComposeRule&type=Code. No instances of this happening internally in non-archived projects.

