### PR TITLE
Added Windows default paths for docker.exe and docker-compose.exe

### DIFF
--- a/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/execution/DockerComposeExecutable.java
+++ b/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/execution/DockerComposeExecutable.java
@@ -32,7 +32,8 @@ public abstract class DockerComposeExecutable implements Executable {
     private static final DockerCommandLocations DOCKER_COMPOSE_LOCATIONS = new DockerCommandLocations(
             System.getenv("DOCKER_COMPOSE_LOCATION"),
             "/usr/local/bin/docker-compose",
-            "/usr/bin/docker-compose"
+            "/usr/bin/docker-compose",
+            "/Program Files/Docker/Docker/resources/bin/docker-compose.exe"
     );
 
     private static String defaultDockerComposePath() {

--- a/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/execution/DockerExecutable.java
+++ b/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/execution/DockerExecutable.java
@@ -29,7 +29,8 @@ public abstract class DockerExecutable implements Executable {
     private static final DockerCommandLocations DOCKER_LOCATIONS = new DockerCommandLocations(
             System.getenv("DOCKER_LOCATION"),
             "/usr/local/bin/docker",
-            "/usr/bin/docker"
+            "/usr/bin/docker",
+            "/Program Files/Docker/Docker/resources/bin/docker.exe"
     );
 
     @Value.Parameter protected abstract DockerConfiguration dockerConfiguration();


### PR DESCRIPTION
## Before this PR
this docker-compose-rule not working out of the box with windows machines, cause there are no default path to docker executables

## After this PR
now it should work with windows

## Possible downsides?
didn't find any downsides

