### PR TITLE
Add origin git remote url path to reports

### DIFF
--- a/changelog/@unreleased/pr-322.v2.yml
+++ b/changelog/@unreleased/pr-322.v2.yml
@@ -1,0 +1,5 @@
+type: feature
+feature:
+  description: Stats reporting will now send the path of the origin git url.
+  links:
+  - https://github.com/palantir/docker-compose-rule/pull/322

--- a/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/reporting/GitUtils.java
+++ b/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/reporting/GitUtils.java
@@ -20,6 +20,6 @@ class GitUtils {
     private GitUtils() { }
 
     public static String parsePathFromGitRemoteUrl(String gitRemoteUrl) {
-        return gitRemoteUrl.replaceAll("(?:ssh://)?(?:.+@)?.*?[:/](?:\\d+/)?(.*)\\.git", "$1");
+        return gitRemoteUrl.replaceAll("(?:ssh://)?(?:.+@)?.*?[:/](?:~[^/]*/)?(?:\\d+/)?(.*)\\.git(?:/)?", "$1");
     }
 }

--- a/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/reporting/GitUtils.java
+++ b/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/reporting/GitUtils.java
@@ -1,0 +1,25 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.docker.compose.reporting;
+
+class GitUtils {
+    private GitUtils() { }
+
+    public static String parsePathFromGitRemoteUrl(String gitRemoteUrl) {
+        return gitRemoteUrl.replaceAll("(?:ssh://)?(?:.+@)?.*?[:/](?:\\d+/)?(.*)\\.git", "$1");
+    }
+}

--- a/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/reporting/GitUtils.java
+++ b/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/reporting/GitUtils.java
@@ -16,10 +16,12 @@
 
 package com.palantir.docker.compose.reporting;
 
+import java.util.Optional;
+
 class GitUtils {
     private GitUtils() { }
 
-    public static String parsePathFromGitRemoteUrl(String gitRemoteUrl) {
+    public static Optional<String> parsePathFromGitRemoteUrl(String gitRemoteUrl) {
         String sshOrGit     = "(?:(?:ssh|git)://)?";
         String user         = "(?:.+@)?";
         String hostname     = ".*?";
@@ -34,9 +36,9 @@ class GitUtils {
 
         String httpRegex = "https?://.*?/(.*?)\\.git";
 
-        return gitRemoteUrl
+        return Optional.of(gitRemoteUrl
                 .replaceAll(httpRegex, "$1")
                 .replaceAll(sshRegex, "$1")
-                .replaceAll("/$", "");
+                .replaceAll("/$", ""));
     }
 }

--- a/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/reporting/GitUtils.java
+++ b/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/reporting/GitUtils.java
@@ -22,23 +22,32 @@ class GitUtils {
     private GitUtils() { }
 
     public static Optional<String> parsePathFromGitRemoteUrl(String gitRemoteUrl) {
+        return Optional.of(gitRemoteUrl
+                .replaceAll(httpRegex(), "$1")
+                .replaceAll(sshRegex(), "$1")
+                .replaceAll("/$", ""));
+    }
+
+    private static String sshRegex() {
         String sshOrGit     = "(?:(?:ssh|git)://)?";
         String user         = "(?:.+@)?";
         String hostname     = ".*?";
         String separator    = "[:/]";
         String port         = "(?:\\d+/)?";
         String squigglyUser = "(?:~[^/]*/)?";
-        String pathCapture  = "(.*)";
-        String dotGit       = "\\.git";
+        String pathCapture  = "(.*?)";
+        String dotGit       = "(:?\\.git)";
 
-        String sshRegex =
-                sshOrGit + user + hostname + separator + port + squigglyUser + pathCapture + dotGit;
+        return sshOrGit + user + hostname + separator + port + squigglyUser + pathCapture + dotGit;
+    }
 
-        String httpRegex = "https?://.*?/(.*?)\\.git";
+    private static String httpRegex() {
+        String http        = "https?://";
+        String hostname    = ".*?";
+        String separator   = "/";
+        String pathCapture = "(.*?)";
+        String dotGit      = "(:?\\.git)";
 
-        return Optional.of(gitRemoteUrl
-                .replaceAll(httpRegex, "$1")
-                .replaceAll(sshRegex, "$1")
-                .replaceAll("/$", ""));
+        return http + hostname + separator + pathCapture + dotGit;
     }
 }

--- a/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/reporting/GitUtils.java
+++ b/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/reporting/GitUtils.java
@@ -20,6 +20,20 @@ class GitUtils {
     private GitUtils() { }
 
     public static String parsePathFromGitRemoteUrl(String gitRemoteUrl) {
-        return gitRemoteUrl.replaceAll("(?:ssh://)?(?:.+@)?.*?[:/](?:~[^/]*/)?(?:\\d+/)?(.*)\\.git(?:/)?", "$1");
+        String ssh          = "(?:ssh://)?";
+        String user         = "(?:.+@)?";
+        String hostname     = ".*?";
+        String separator    = "[:/]";
+        String port         = "(?:\\d+/)?";
+        String squigglyUser = "(?:~[^/]*/)?";
+        String pathCapture  = "(.*)";
+        String dotGit       = "\\.git";
+
+        String sshRegex =
+                ssh + user + hostname + separator + port + squigglyUser + pathCapture + dotGit;
+
+        return gitRemoteUrl
+                .replaceAll(sshRegex, "$1")
+                .replaceAll("/$", "");
     }
 }

--- a/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/reporting/GitUtils.java
+++ b/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/reporting/GitUtils.java
@@ -20,7 +20,7 @@ class GitUtils {
     private GitUtils() { }
 
     public static String parsePathFromGitRemoteUrl(String gitRemoteUrl) {
-        String ssh          = "(?:ssh://)?";
+        String sshOrGit     = "(?:(?:ssh|git)://)?";
         String user         = "(?:.+@)?";
         String hostname     = ".*?";
         String separator    = "[:/]";
@@ -30,9 +30,12 @@ class GitUtils {
         String dotGit       = "\\.git";
 
         String sshRegex =
-                ssh + user + hostname + separator + port + squigglyUser + pathCapture + dotGit;
+                sshOrGit + user + hostname + separator + port + squigglyUser + pathCapture + dotGit;
+
+        String httpRegex = "https?://.*?/(.*?)\\.git";
 
         return gitRemoteUrl
+                .replaceAll(httpRegex, "$1")
                 .replaceAll(sshRegex, "$1")
                 .replaceAll("/$", "");
     }

--- a/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/reporting/ReportCompiler.java
+++ b/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/reporting/ReportCompiler.java
@@ -106,9 +106,10 @@ final class ReportCompiler implements Reporter {
                 .branch(runProcess("git", "rev-parse", "--abbrev-ref", "HEAD"))
                 .commit(runProcess("git", "rev-parse", "HEAD"))
                 .dirty(runProcess("git", "status", "--short").map(output -> !output.isEmpty()))
+                .originPath(runProcess("git", "ls-remote", "--get-url", "origin")
+                        .map(GitUtils::parsePathFromGitRemoteUrl))
                 .build();
     }
-
     private Optional<String> runProcess(String... args) {
         try {
             Process process = new ProcessBuilder()

--- a/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/reporting/ReportCompiler.java
+++ b/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/reporting/ReportCompiler.java
@@ -107,7 +107,7 @@ final class ReportCompiler implements Reporter {
                 .commit(runProcess("git", "rev-parse", "HEAD"))
                 .dirty(runProcess("git", "status", "--short").map(output -> !output.isEmpty()))
                 .originPath(runProcess("git", "ls-remote", "--get-url", "origin")
-                        .map(GitUtils::parsePathFromGitRemoteUrl))
+                        .flatMap(GitUtils::parsePathFromGitRemoteUrl))
                 .build();
     }
     private Optional<String> runProcess(String... args) {

--- a/docker-compose-rule-core/src/test/java/com/palantir/docker/compose/reporting/GitUtilsTest.java
+++ b/docker-compose-rule-core/src/test/java/com/palantir/docker/compose/reporting/GitUtilsTest.java
@@ -36,6 +36,9 @@ public class GitUtilsTest {
                 { "github.some.url:3456/palantir/docker-compose-rule.git", "palantir/docker-compose-rule" },
                 { "ssh://user@github.some.url:3456/palantir/docker-compose-rule.git", "palantir/docker-compose-rule" },
                 { "ssh://github.some.url/palantir/docker-compose-rule.git", "palantir/docker-compose-rule" },
+                { "git@github.com:palantir/docker-compose-rule.git/", "palantir/docker-compose-rule" },
+                { "ssh://user@github.some.url/~/palantir/docker-compose-rule.git", "palantir/docker-compose-rule" },
+                { "user@github.some.url/~user/palantir/docker-compose-rule.git", "palantir/docker-compose-rule" },
                 });
     }
 

--- a/docker-compose-rule-core/src/test/java/com/palantir/docker/compose/reporting/GitUtilsTest.java
+++ b/docker-compose-rule-core/src/test/java/com/palantir/docker/compose/reporting/GitUtilsTest.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Optional;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -28,28 +29,32 @@ import org.junit.runners.Parameterized;
 public class GitUtilsTest {
 
     @Parameterized.Parameters(name = "{0}")
-    public static Collection<String[]> params() {
-        return Arrays.asList(new String[][] {
-                { "git@github.com:palantir/docker-compose-rule.git", "palantir/docker-compose-rule" },
-                { "user@github.some.corp:palantir/docker-compose-rule.git", "palantir/docker-compose-rule" },
-                { "github.some.url:palantir/docker-compose-rule.git", "palantir/docker-compose-rule" },
-                { "github.some.url:3456/palantir/docker-compose-rule.git", "palantir/docker-compose-rule" },
-                { "ssh://user@github.some.url:3456/palantir/docker-compose-rule.git", "palantir/docker-compose-rule" },
-                { "ssh://github.some.url/palantir/docker-compose-rule.git", "palantir/docker-compose-rule" },
-                { "git@github.com:palantir/docker-compose-rule.git/", "palantir/docker-compose-rule" },
-                { "ssh://user@github.some.url/~/palantir/docker-compose-rule.git", "palantir/docker-compose-rule" },
-                { "user@github.some.url/~user/palantir/docker-compose-rule.git", "palantir/docker-compose-rule" },
-                { "git://github.some.url/~user/palantir/docker-compose-rule.git", "palantir/docker-compose-rule" },
-                { "http://host.xz/path/to/repo.git/", "path/to/repo" },
-                { "http://host.xz:6575/path/to/repo.git/", "path/to/repo" },
-                { "https://host.xz/path/to/repo.git/", "path/to/repo" },
+    public static Collection<Object[]> params() {
+        return Arrays.asList(new Object[][] {
+                { "git@github.com:palantir/docker-compose-rule.git", yes("palantir/docker-compose-rule") },
+                { "user@github.some.corp:palantir/docker-compose-rule.git", yes("palantir/docker-compose-rule") },
+                { "github.some.url:palantir/docker-compose-rule.git", yes("palantir/docker-compose-rule") },
+                { "github.some.url:3456/palantir/docker-compose-rule.git", yes("palantir/docker-compose-rule") },
+                { "ssh://user@github.some.url:3456/palantir/docker-compose.git", yes("palantir/docker-compose") },
+                { "ssh://github.some.url/palantir/docker-compose-rule.git", yes("palantir/docker-compose-rule") },
+                { "git@github.com:palantir/docker-compose-rule.git/", yes("palantir/docker-compose-rule") },
+                { "ssh://user@github.some.url/~/palantir/docker-compose.git", yes("palantir/docker-compose") },
+                { "user@github.some.url/~user/palantir/docker-compose-rule.git", yes("palantir/docker-compose-rule") },
+                { "git://github.some.url/~user/palantir/docker-compose-rule.git", yes("palantir/docker-compose-rule") },
+                { "http://host.xz/path/to/repo.git/", yes("path/to/repo") },
+                { "http://host.xz:6575/path/to/repo-blah.git/", yes("path/to/repo-blah") },
+                { "https://host.xz/path/to/repo.git/", yes("path/to/repo") },
                 });
     }
 
-    private final String input;
-    private final String expected;
+    private static Optional<String> yes(String str) {
+        return Optional.of(str);
+    }
 
-    public GitUtilsTest(String input, String expected) {
+    private final String input;
+    private final Optional<String> expected;
+
+    public GitUtilsTest(String input, Optional<String> expected) {
         this.input = input;
         this.expected = expected;
     }

--- a/docker-compose-rule-core/src/test/java/com/palantir/docker/compose/reporting/GitUtilsTest.java
+++ b/docker-compose-rule-core/src/test/java/com/palantir/docker/compose/reporting/GitUtilsTest.java
@@ -50,9 +50,9 @@ public class GitUtilsTest {
 
                 { "file://lol/some/path", no() },
                 { "/lol/some/path", no() },
+                { "/lol/some/path/", no() },
                 { "lol/some/path", no() },
-
-                { "lol/some/path", no() },
+                { "lol/some/path/", no() },
                 });
     }
 

--- a/docker-compose-rule-core/src/test/java/com/palantir/docker/compose/reporting/GitUtilsTest.java
+++ b/docker-compose-rule-core/src/test/java/com/palantir/docker/compose/reporting/GitUtilsTest.java
@@ -40,15 +40,28 @@ public class GitUtilsTest {
                 { "git@github.com:palantir/docker-compose-rule.git/", yes("palantir/docker-compose-rule") },
                 { "ssh://user@github.some.url/~/palantir/docker-compose.git", yes("palantir/docker-compose") },
                 { "user@github.some.url/~user/palantir/docker-compose-rule.git", yes("palantir/docker-compose-rule") },
+
                 { "git://github.some.url/~user/palantir/docker-compose-rule.git", yes("palantir/docker-compose-rule") },
+
                 { "http://host.xz/path/to/repo.git/", yes("path/to/repo") },
                 { "http://host.xz:6575/path/to/repo-blah.git/", yes("path/to/repo-blah") },
                 { "https://host.xz/path/to/repo.git/", yes("path/to/repo") },
+                { "https://user:tokenauth@host.name/some/path/to/place", yes("some/path/to/place") },
+
+                { "file://lol/some/path", no() },
+                { "/lol/some/path", no() },
+                { "lol/some/path", no() },
+
+                { "lol/some/path", no() },
                 });
     }
 
     private static Optional<String> yes(String str) {
         return Optional.of(str);
+    }
+
+    private static Optional<String> no() {
+        return Optional.empty();
     }
 
     private final String input;

--- a/docker-compose-rule-core/src/test/java/com/palantir/docker/compose/reporting/GitUtilsTest.java
+++ b/docker-compose-rule-core/src/test/java/com/palantir/docker/compose/reporting/GitUtilsTest.java
@@ -39,6 +39,10 @@ public class GitUtilsTest {
                 { "git@github.com:palantir/docker-compose-rule.git/", "palantir/docker-compose-rule" },
                 { "ssh://user@github.some.url/~/palantir/docker-compose-rule.git", "palantir/docker-compose-rule" },
                 { "user@github.some.url/~user/palantir/docker-compose-rule.git", "palantir/docker-compose-rule" },
+                { "git://github.some.url/~user/palantir/docker-compose-rule.git", "palantir/docker-compose-rule" },
+                { "http://host.xz/path/to/repo.git/", "path/to/repo" },
+                { "http://host.xz:6575/path/to/repo.git/", "path/to/repo" },
+                { "https://host.xz/path/to/repo.git/", "path/to/repo" },
                 });
     }
 

--- a/docker-compose-rule-core/src/test/java/com/palantir/docker/compose/reporting/GitUtilsTest.java
+++ b/docker-compose-rule-core/src/test/java/com/palantir/docker/compose/reporting/GitUtilsTest.java
@@ -1,0 +1,55 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.docker.compose.reporting;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Arrays;
+import java.util.Collection;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+@RunWith(Parameterized.class)
+public class GitUtilsTest {
+
+    @Parameterized.Parameters(name = "{0}")
+    public static Collection<String[]> params() {
+        return Arrays.asList(new String[][] {
+                { "git@github.com:palantir/docker-compose-rule.git", "palantir/docker-compose-rule" },
+                { "user@github.some.corp:palantir/docker-compose-rule.git", "palantir/docker-compose-rule" },
+                { "github.some.url:palantir/docker-compose-rule.git", "palantir/docker-compose-rule" },
+                { "github.some.url:3456/palantir/docker-compose-rule.git", "palantir/docker-compose-rule" },
+                { "ssh://user@github.some.url:3456/palantir/docker-compose-rule.git", "palantir/docker-compose-rule" },
+                { "ssh://github.some.url/palantir/docker-compose-rule.git", "palantir/docker-compose-rule" },
+                });
+    }
+
+    private final String input;
+    private final String expected;
+
+    public GitUtilsTest(String input, String expected) {
+        this.input = input;
+        this.expected = expected;
+    }
+
+    @Test
+    public void parse_out_git_remote_url() {
+        assertThat(GitUtils.parsePathFromGitRemoteUrl(input)).isEqualTo(expected);
+    }
+
+}

--- a/docker-compose-rule-events-api/src/main/conjure/report-api.yml
+++ b/docker-compose-rule-events-api/src/main/conjure/report-api.yml
@@ -10,6 +10,7 @@ types:
           branch: optional<string>
           commit: optional<string>
           dirty: optional<boolean>
+          originPath: optional<string>
 
       TestDescription:
         fields:

--- a/versions.lock
+++ b/versions.lock
@@ -12,7 +12,7 @@ com.fasterxml.jackson.module:jackson-module-afterburner:2.9.9 (1 constraints: 5a
 com.github.zafarkhaja:java-semver:0.9.0 (1 constraints: 0b050636)
 com.google.code.findbugs:jsr305:3.0.2 (1 constraints: 980fcc86)
 com.google.errorprone:error_prone_annotations:2.3.3 (1 constraints: 041129c0)
-com.google.guava:guava:20.0 (3 constraints: fb284187)
+com.google.guava:guava:21.0 (3 constraints: f528d884)
 com.jayway.awaitility:awaitility:1.7.0 (1 constraints: 0a050536)
 com.palantir.conjure.java:conjure-lib:3.15.0 (1 constraints: 3b05443b)
 com.palantir.conjure.java.api:errors:2.3.0 (1 constraints: ed0f7399)

--- a/versions.props
+++ b/versions.props
@@ -1,6 +1,6 @@
 com.github.stefanbirkner:system-rules = 1.19.0
 com.github.zafarkhaja:java-semver = 0.9.0
-com.google.guava:guava = 18.0
+com.google.guava:guava = 21.0
 com.jayway.awaitility:awaitility = 1.7.0
 commons-io:commons-io = 2.6
 joda-time:joda-time = 2.10.3


### PR DESCRIPTION
## Before this PR
Reports do not have the path of the git repo being used included in it, so we cannot tell which repo people are using DCR on.

## After this PR
==COMMIT_MSG==
Stats reporting will now send the path of the origin git url.
==COMMIT_MSG==

## Possible downsides?
Accidentally scoop up a sensitive token or similar that's in the remote url. There is a test for the format we use for this internally. Also people have to opt-in to this codepath by creating a `.docker-compose-rule.yml` file anyway, so we won't impact real OSS users.

