### PR TITLE
Remove duplication by inverting BuilderExtensions control

### DIFF
--- a/docker-compose-junit-jupiter/src/main/java/com/palantir/docker/compose/DockerComposeExtension.java
+++ b/docker-compose-junit-jupiter/src/main/java/com/palantir/docker/compose/DockerComposeExtension.java
@@ -16,20 +16,7 @@
 
 package com.palantir.docker.compose;
 
-import static com.palantir.docker.compose.connection.waiting.ClusterHealthCheck.serviceHealthCheck;
-import static com.palantir.docker.compose.connection.waiting.ClusterHealthCheck.transformingHealthCheck;
-
-import com.palantir.docker.compose.configuration.DockerComposeFiles;
-import com.palantir.docker.compose.configuration.ShutdownStrategy;
-import com.palantir.docker.compose.connection.Container;
-import com.palantir.docker.compose.connection.DockerPort;
-import com.palantir.docker.compose.connection.waiting.ClusterHealthCheck;
-import com.palantir.docker.compose.connection.waiting.ClusterWait;
-import com.palantir.docker.compose.connection.waiting.HealthCheck;
-import com.palantir.docker.compose.logging.FileLogCollector;
-import java.util.List;
 import org.immutables.value.Value;
-import org.joda.time.ReadableDuration;
 import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -53,65 +40,7 @@ public abstract class DockerComposeExtension extends DockerComposeManager
         return new Builder();
     }
 
-    public static class Builder extends ImmutableDockerComposeExtension.Builder implements BuilderExtensions {
-        @Override
-        public Builder file(String dockerComposeYmlFile) {
-            return files(DockerComposeFiles.from(dockerComposeYmlFile));
-        }
-
-        @Override
-        public Builder saveLogsTo(String path) {
-            return logCollector(FileLogCollector.fromPath(path));
-        }
-
-        @Override
-        public Builder skipShutdown(boolean skipShutdown) {
-            if (skipShutdown) {
-                return shutdownStrategy(ShutdownStrategy.SKIP);
-            }
-
-            return this;
-        }
-
-        @Override
-        public Builder waitingForService(String serviceName, HealthCheck<Container> healthCheck) {
-            return waitingForService(serviceName, healthCheck, DEFAULT_TIMEOUT);
-        }
-
-        @Override
-        public Builder waitingForService(String serviceName, HealthCheck<Container> healthCheck, ReadableDuration timeout) {
-            ClusterHealthCheck clusterHealthCheck = serviceHealthCheck(serviceName, healthCheck);
-            return addClusterWait(new ClusterWait(clusterHealthCheck, timeout));
-        }
-
-        @Override
-        public Builder waitingForServices(List<String> services, HealthCheck<List<Container>> healthCheck) {
-            return waitingForServices(services, healthCheck, DEFAULT_TIMEOUT);
-        }
-
-        @Override
-        public Builder waitingForServices(List<String> services, HealthCheck<List<Container>> healthCheck, ReadableDuration timeout) {
-            ClusterHealthCheck clusterHealthCheck = serviceHealthCheck(services, healthCheck);
-            return addClusterWait(new ClusterWait(clusterHealthCheck, timeout));
-        }
-
-        @Override
-        public Builder waitingForHostNetworkedPort(int port, HealthCheck<DockerPort> healthCheck) {
-            return waitingForHostNetworkedPort(port, healthCheck, DEFAULT_TIMEOUT);
-        }
-
-        @Override
-        public Builder waitingForHostNetworkedPort(int port, HealthCheck<DockerPort> healthCheck, ReadableDuration timeout) {
-            ClusterHealthCheck clusterHealthCheck = transformingHealthCheck(cluster ->
-                    new DockerPort(cluster.ip(), port, port), healthCheck);
-            return addClusterWait(new ClusterWait(clusterHealthCheck, timeout));
-        }
-
-        @Override
-        public Builder clusterWaits(Iterable<? extends ClusterWait> elements) {
-            return addAllClusterWaits(elements);
-        }
-
+    public static class Builder extends ImmutableDockerComposeExtension.Builder implements BuilderExtensions<Builder> {
         @Override
         public DockerComposeExtension build() {
             return super.build();

--- a/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/DockerComposeManager.java
+++ b/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/DockerComposeManager.java
@@ -281,18 +281,18 @@ public abstract class DockerComposeManager {
         return dockerCompose().run(options, containerName, arguments);
     }
 
-    public interface BuilderExtensions<B> {
-        B files(DockerComposeFiles files);
+    public interface BuilderExtensions<TSelf extends BuilderExtensions<TSelf>> {
+        TSelf files(DockerComposeFiles files);
 
-        B logCollector(LogCollector logCollector);
+        TSelf logCollector(LogCollector logCollector);
 
-        B shutdownStrategy(ShutdownStrategy shutdownStrategy);
+        TSelf shutdownStrategy(ShutdownStrategy shutdownStrategy);
 
-        B addClusterWait(ClusterWait element);
+        TSelf addClusterWait(ClusterWait element);
 
-        B addAllClusterWaits(Iterable<? extends ClusterWait> elements);
+        TSelf addAllClusterWaits(Iterable<? extends ClusterWait> elements);
 
-        default B file(String dockerComposeYmlFile) {
+        default TSelf file(String dockerComposeYmlFile) {
             return files(DockerComposeFiles.from(dockerComposeYmlFile));
         }
 
@@ -304,7 +304,7 @@ public abstract class DockerComposeManager {
          *
          * @param path directory into which log files should be saved
          */
-        default B saveLogsTo(String path) {
+        default TSelf saveLogsTo(String path) {
             return logCollector(FileLogCollector.fromPath(path));
         }
 
@@ -313,45 +313,45 @@ public abstract class DockerComposeManager {
          * @deprecated Please use {@link DockerComposeManager#shutdownStrategy()} with {@link ShutdownStrategy#SKIP} instead.
          */
         @Deprecated
-        default B skipShutdown(boolean skipShutdown) {
+        default TSelf skipShutdown(boolean skipShutdown) {
             if (skipShutdown) {
                 return shutdownStrategy(ShutdownStrategy.SKIP);
             }
 
-            return (B) this;
+            return (TSelf) this;
         }
 
-        default B waitingForService(String serviceName, HealthCheck<Container> healthCheck) {
+        default TSelf waitingForService(String serviceName, HealthCheck<Container> healthCheck) {
             return waitingForService(serviceName, healthCheck, DEFAULT_TIMEOUT);
         }
 
-        default B waitingForService(String serviceName, HealthCheck<Container> healthCheck,
+        default TSelf waitingForService(String serviceName, HealthCheck<Container> healthCheck,
                 ReadableDuration timeout) {
             ClusterHealthCheck clusterHealthCheck = serviceHealthCheck(serviceName, healthCheck);
             return addClusterWait(new ClusterWait(clusterHealthCheck, timeout));
         }
 
-        default B waitingForServices(List<String> services, HealthCheck<List<Container>> healthCheck) {
+        default TSelf waitingForServices(List<String> services, HealthCheck<List<Container>> healthCheck) {
             return waitingForServices(services, healthCheck, DEFAULT_TIMEOUT);
         }
 
-        default B waitingForServices(List<String> services, HealthCheck<List<Container>> healthCheck,
+        default TSelf waitingForServices(List<String> services, HealthCheck<List<Container>> healthCheck,
                 ReadableDuration timeout) {
             ClusterHealthCheck clusterHealthCheck = serviceHealthCheck(services, healthCheck);
             return addClusterWait(new ClusterWait(clusterHealthCheck, timeout));
         }
 
-        default B waitingForHostNetworkedPort(int port, HealthCheck<DockerPort> healthCheck) {
+        default TSelf waitingForHostNetworkedPort(int port, HealthCheck<DockerPort> healthCheck) {
             return waitingForHostNetworkedPort(port, healthCheck, DEFAULT_TIMEOUT);
         }
 
-        default B waitingForHostNetworkedPort(int port, HealthCheck<DockerPort> healthCheck,
+        default TSelf waitingForHostNetworkedPort(int port, HealthCheck<DockerPort> healthCheck,
                 ReadableDuration timeout) {
             ClusterHealthCheck clusterHealthCheck = transformingHealthCheck(cluster -> new DockerPort(cluster.ip(), port, port), healthCheck);
             return addClusterWait(new ClusterWait(clusterHealthCheck, timeout));
         }
 
-        default B clusterWaits(Iterable<? extends ClusterWait> elements) {
+        default TSelf clusterWaits(Iterable<? extends ClusterWait> elements) {
             return addAllClusterWaits(elements);
         }
     }

--- a/docker-compose-rule-junit4/src/main/java/com/palantir/docker/compose/DockerComposeRule.java
+++ b/docker-compose-rule-junit4/src/main/java/com/palantir/docker/compose/DockerComposeRule.java
@@ -16,22 +16,9 @@
 
 package com.palantir.docker.compose;
 
-import static com.palantir.docker.compose.connection.waiting.ClusterHealthCheck.serviceHealthCheck;
-import static com.palantir.docker.compose.connection.waiting.ClusterHealthCheck.transformingHealthCheck;
-
-import com.palantir.docker.compose.configuration.DockerComposeFiles;
-import com.palantir.docker.compose.configuration.ShutdownStrategy;
-import com.palantir.docker.compose.connection.Container;
-import com.palantir.docker.compose.connection.DockerPort;
-import com.palantir.docker.compose.connection.waiting.ClusterHealthCheck;
-import com.palantir.docker.compose.connection.waiting.ClusterWait;
-import com.palantir.docker.compose.connection.waiting.HealthCheck;
-import com.palantir.docker.compose.logging.FileLogCollector;
 import com.palantir.docker.compose.report.TestDescription;
-import java.util.List;
 import java.util.Optional;
 import org.immutables.value.Value;
-import org.joda.time.ReadableDuration;
 import org.junit.rules.TestRule;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
@@ -64,65 +51,7 @@ public abstract class DockerComposeRule extends DockerComposeManager implements 
         return new Builder();
     }
 
-    public static class Builder extends ImmutableDockerComposeRule.Builder implements BuilderExtensions {
-        @Override
-        public Builder file(String dockerComposeYmlFile) {
-            return files(DockerComposeFiles.from(dockerComposeYmlFile));
-        }
-
-        @Override
-        public Builder saveLogsTo(String path) {
-            return logCollector(FileLogCollector.fromPath(path));
-        }
-
-        @Override
-        public Builder skipShutdown(boolean skipShutdown) {
-            if (skipShutdown) {
-                return shutdownStrategy(ShutdownStrategy.SKIP);
-            }
-
-            return this;
-        }
-
-        @Override
-        public Builder waitingForService(String serviceName, HealthCheck<Container> healthCheck) {
-            return waitingForService(serviceName, healthCheck, DEFAULT_TIMEOUT);
-        }
-
-        @Override
-        public Builder waitingForService(String serviceName, HealthCheck<Container> healthCheck, ReadableDuration timeout) {
-            ClusterHealthCheck clusterHealthCheck = serviceHealthCheck(serviceName, healthCheck);
-            return addClusterWait(new ClusterWait(clusterHealthCheck, timeout));
-        }
-
-        @Override
-        public Builder waitingForServices(List<String> services, HealthCheck<List<Container>> healthCheck) {
-            return waitingForServices(services, healthCheck, DEFAULT_TIMEOUT);
-        }
-
-        @Override
-        public Builder waitingForServices(List<String> services, HealthCheck<List<Container>> healthCheck, ReadableDuration timeout) {
-            ClusterHealthCheck clusterHealthCheck = serviceHealthCheck(services, healthCheck);
-            return addClusterWait(new ClusterWait(clusterHealthCheck, timeout));
-        }
-
-        @Override
-        public Builder waitingForHostNetworkedPort(int port, HealthCheck<DockerPort> healthCheck) {
-            return waitingForHostNetworkedPort(port, healthCheck, DEFAULT_TIMEOUT);
-        }
-
-        @Override
-        public Builder waitingForHostNetworkedPort(int port, HealthCheck<DockerPort> healthCheck, ReadableDuration timeout) {
-            ClusterHealthCheck clusterHealthCheck = transformingHealthCheck(cluster ->
-                    new DockerPort(cluster.ip(), port, port), healthCheck);
-            return addClusterWait(new ClusterWait(clusterHealthCheck, timeout));
-        }
-
-        @Override
-        public Builder clusterWaits(Iterable<? extends ClusterWait> elements) {
-            return addAllClusterWaits(elements);
-        }
-
+    public static class Builder extends ImmutableDockerComposeRule.Builder implements BuilderExtensions<Builder> {
         @Override
         public DockerComposeRule build() {
             return super.build();


### PR DESCRIPTION
## Before this PR
Lots of duplication of logic in various builders

## After this PR
By inverting how BuilderExtensions work we can have the individual builders inherit the common behaviour

