### PR TITLE
Fix parsing of docker-compose output.

### DIFF
--- a/changelog/@unreleased/pr-424.v2.yml
+++ b/changelog/@unreleased/pr-424.v2.yml
@@ -1,0 +1,9 @@
+type: fix
+fix:
+  description: |+
+    Fix parsing of docker-compose output
+
+    Set the `COLUMNS` environment variable to an artificially large value for the docker-compose process. This works around newer versions of docker-compose (at least 1.25.0-rc4+) which adjust their output based on the width of the terminal.
+
+  links:
+  - https://github.com/palantir/docker-compose-rule/pull/424

--- a/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/connection/DockerMachine.java
+++ b/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/connection/DockerMachine.java
@@ -155,6 +155,10 @@ public class DockerMachine implements DockerConfiguration {
             String hostIp = new RemoteHostIpResolver().resolveIp(dockerHost);
 
             Map<String, String> environment = ImmutableMap.<String, String>builder()
+                    // 2019-12-17: newer docker-compose adjusts its output based on the number of columns available
+                    // in the terminal. This interferes with parsing of the output of docker-compose, so "COLUMNS" is
+                    // set to an artificially large value.
+                                                          .put("COLUMNS", "10000")
                                                           .putAll(dockerEnvironment)
                                                           .putAll(additionalEnvironment)
                                                           .build();


### PR DESCRIPTION
## Before this PR
Newer versions of docker-compose (at least 1.25.0-rc4) adjust the output based on the number of columns available in the terminal. This interferes with parsing of the output and can cause errors like "No internal port X for container Y" when the port does exist.  This is because of a parse failure while parsing the output of `docker-compose ps`.

## After this PR
==COMMIT_MSG==
Set the `COLUMNS` environment variable to an artificially large value for the `docker-compose` process.  This works around newer versions of docker-compose (at least 1.25.0-rc4+) which adjust their output based on the width of the terminal.
==COMMIT_MSG==
