### PR TITLE
Actually print port mappings

### DIFF
--- a/changelog/@unreleased/pr-425.v2.yml
+++ b/changelog/@unreleased/pr-425.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Include port mappings in exception thrown when failing to resolve a port.
+  links:
+  - https://github.com/palantir/docker-compose-rule/pull/425

--- a/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/connection/Container.java
+++ b/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/connection/Container.java
@@ -84,11 +84,12 @@ public class Container {
     }
 
     public DockerPort port(int internalPort) {
-        return portMappings.get()
-                           .stream()
-                           .filter(port -> port.getInternalPort() == internalPort)
-                           .findFirst()
-                           .orElseThrow(() -> new IllegalArgumentException("No internal port '" + internalPort + "' for container '" + containerName + "': " + portMappings));
+        Ports ports = portMappings.get();
+        return ports.stream()
+                .filter(port -> port.getInternalPort() == internalPort)
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException(
+                        "No internal port '" + internalPort + "' for container '" + containerName + "': " + ports));
     }
 
     public void start() throws IOException, InterruptedException {

--- a/docker-compose-rule-core/src/test/java/com/palantir/docker/compose/connection/ContainerShould.java
+++ b/docker-compose-rule-core/src/test/java/com/palantir/docker/compose/connection/ContainerShould.java
@@ -102,6 +102,7 @@ public class ContainerShould {
         env.availableService("service", IP, 5400, 5400);
         exception.expect(IllegalArgumentException.class);
         exception.expectMessage("No internal port '5432' for container 'service'");
+        exception.expectMessage("externalPort=5400, internalPort=5400");
         container.port(5432);
     }
 


### PR DESCRIPTION
## Before this PR
When `Container#port` throws an IllegalArgumentException, the message contains the lambda that gets the port mappings as opposed to the mappings themselves. For example (scroll right):

```
java.lang.IllegalArgumentException: No internal port '8107' for container '<redacted>': com.palantir.docker.compose.connection.Container$$Lambda$139/0x000000080026e040@5e9b4687
        at com.palantir.docker.compose.connection.Container.lambda$port$4(Container.java:91)
        at java.base/java.util.Optional.orElseThrow(Optional.java:408)
        at com.palantir.docker.compose.connection.Container.port(Container.java:91)
        ...
```

## After this PR
==COMMIT_MSG==
Include port mappings in exception thrown when failing to resolve a port.
==COMMIT_MSG==
