### PR TITLE
Add option to omit the project name

### DIFF
--- a/changelog/@unreleased/pr-495.v2.yml
+++ b/changelog/@unreleased/pr-495.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Add option to omit the project name
+  links:
+  - https://github.com/palantir/docker-compose-rule/pull/495

--- a/docker-compose-rule-core/src/test/java/com/palantir/docker/compose/configuration/ProjectNameShould.java
+++ b/docker-compose-rule-core/src/test/java/com/palantir/docker/compose/configuration/ProjectNameShould.java
@@ -17,6 +17,7 @@ package com.palantir.docker.compose.configuration;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
@@ -67,6 +68,12 @@ public class ProjectNameShould {
     }
 
     @Test
+    public void return_empty_command_when_omitted() {
+        List<String> command = ProjectName.omit().constructComposeFileCommand();
+        assertThat(command, empty());
+    }
+
+    @Test
     public void reject_blanks_in_from_string() {
         exception.expect(IllegalStateException.class);
         exception.expectMessage("ProjectName must not be blank.");
@@ -76,7 +83,8 @@ public class ProjectNameShould {
     @Test
     public void match_validation_behavior_of_docker_compose_cli() {
         exception.expect(IllegalStateException.class);
-        exception.expectMessage("ProjectName 'Crazy#Proj ect!Name' not allowed, please use lowercase letters and numbers only.");
+        exception.expectMessage(
+                "ProjectName 'Crazy#Proj ect!Name' not allowed, please use lowercase letters and numbers only.");
         ProjectName.fromString("Crazy#Proj ect!Name");
     }
 


### PR DESCRIPTION
## Before this PR

If not set, the `ProjectName` uses `ProjectName#random` to set the docker-compose project name.

In some cases, you want to omit the project name entirely, which makes docker-compose use the name of its current directory as the project name ([reference](https://docs.docker.com/compose/reference/overview/#use--p-to-specify-a-project-name)).

## After this PR

Allow omitting the project name by using `ProjectName#omit`:

```java
DockerComposeExtension.Builder builder = DockerComposeExtension.builder()
        .file("../docker-compose.yml")
        .projectName(ProjectName.omit())
        .build();
```

In this case docker-compose will be run without the `--project-name` option. 

==COMMIT_MSG==
Add option to omit the project name
==COMMIT_MSG==
