### PR TITLE
Also add fixed COLUMNS to localMachine

### DIFF
--- a/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/connection/DockerMachine.java
+++ b/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/connection/DockerMachine.java
@@ -100,12 +100,19 @@ public class DockerMachine implements DockerConfiguration {
         public DockerMachine build() {
             dockerType.validateEnvironmentVariables(systemEnvironment);
             AdditionalEnvironmentValidator.validate(additionalEnvironment);
-            Map<String, String> combinedEnvironment = newHashMap();
-            combinedEnvironment.putAll(systemEnvironment);
-            combinedEnvironment.putAll(additionalEnvironment);
 
             String dockerHost = systemEnvironment.getOrDefault(DOCKER_HOST, "");
-            return new DockerMachine(dockerType.resolveIp(dockerHost), ImmutableMap.copyOf(combinedEnvironment));
+            String hostIp = dockerType.resolveIp(dockerHost);
+
+            Map<String, String> environment = ImmutableMap.<String, String>builder()
+                    // 2019-12-17: newer docker-compose adjusts its output based on the number of columns available
+                    // in the terminal. This interferes with parsing of the output of docker-compose, so "COLUMNS" is
+                    // set to an artificially large value.
+                                                          .put("COLUMNS", "10000")
+                                                          .putAll(systemEnvironment)
+                                                          .putAll(additionalEnvironment)
+                                                          .build();
+            return new DockerMachine(hostIp, environment);
         }
     }
 

--- a/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/connection/DockerMachine.java
+++ b/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/connection/DockerMachine.java
@@ -108,9 +108,9 @@ public class DockerMachine implements DockerConfiguration {
                     // 2019-12-17: newer docker-compose adjusts its output based on the number of columns available
                     // in the terminal. This interferes with parsing of the output of docker-compose, so "COLUMNS" is
                     // set to an artificially large value.
-                                                          .put("COLUMNS", "10000")
                                                           .putAll(systemEnvironment)
                                                           .putAll(additionalEnvironment)
+                                                          .put("COLUMNS", "10000")
                                                           .build();
             return new DockerMachine(hostIp, environment);
         }

--- a/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/connection/DockerMachine.java
+++ b/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/connection/DockerMachine.java
@@ -104,15 +104,15 @@ public class DockerMachine implements DockerConfiguration {
             String dockerHost = systemEnvironment.getOrDefault(DOCKER_HOST, "");
             String hostIp = dockerType.resolveIp(dockerHost);
 
-            Map<String, String> environment = ImmutableMap.<String, String>builder()
-                    // 2019-12-17: newer docker-compose adjusts its output based on the number of columns available
-                    // in the terminal. This interferes with parsing of the output of docker-compose, so "COLUMNS" is
-                    // set to an artificially large value.
-                                                          .putAll(systemEnvironment)
-                                                          .putAll(additionalEnvironment)
-                                                          .put("COLUMNS", "10000")
-                                                          .build();
-            return new DockerMachine(hostIp, environment);
+            Map<String, String> combinedEnvironment = newHashMap();
+            combinedEnvironment.putAll(systemEnvironment);
+            combinedEnvironment.putAll(additionalEnvironment);
+            // 2019-12-17: newer docker-compose adjusts its output based on the number of columns available
+            // in the terminal. This interferes with parsing of the output of docker-compose, so "COLUMNS" is
+            // set to an artificially large value.
+            combinedEnvironment.put("COLUMNS", "10000"):
+
+            return new DockerMachine(hostIp, ImmutableMap.copyOf(combinedEnvironment));
         }
     }
 
@@ -161,15 +161,15 @@ public class DockerMachine implements DockerConfiguration {
             String dockerHost = dockerEnvironment.getOrDefault(DOCKER_HOST, "");
             String hostIp = new RemoteHostIpResolver().resolveIp(dockerHost);
 
-            Map<String, String> environment = ImmutableMap.<String, String>builder()
-                    // 2019-12-17: newer docker-compose adjusts its output based on the number of columns available
-                    // in the terminal. This interferes with parsing of the output of docker-compose, so "COLUMNS" is
-                    // set to an artificially large value.
-                                                          .put("COLUMNS", "10000")
-                                                          .putAll(dockerEnvironment)
-                                                          .putAll(additionalEnvironment)
-                                                          .build();
-            return new DockerMachine(hostIp, environment);
+            Map<String, String> combinedEnvironment = newHashMap();
+            combinedEnvironment.putAll(dockerEnvironment);
+            combinedEnvironment.putAll(additionalEnvironment);
+            // 2019-12-17: newer docker-compose adjusts its output based on the number of columns available
+            // in the terminal. This interferes with parsing of the output of docker-compose, so "COLUMNS" is
+            // set to an artificially large value.
+            combinedEnvironment.put("COLUMNS", "10000"):
+
+            return new DockerMachine(hostIp, ImmutableMap.copyOf(combinedEnvironment));
         }
 
     }

--- a/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/connection/DockerMachine.java
+++ b/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/connection/DockerMachine.java
@@ -110,7 +110,7 @@ public class DockerMachine implements DockerConfiguration {
             // 2019-12-17: newer docker-compose adjusts its output based on the number of columns available
             // in the terminal. This interferes with parsing of the output of docker-compose, so "COLUMNS" is
             // set to an artificially large value.
-            combinedEnvironment.put("COLUMNS", "10000"):
+            combinedEnvironment.put("COLUMNS", "10000");
 
             return new DockerMachine(hostIp, ImmutableMap.copyOf(combinedEnvironment));
         }
@@ -167,7 +167,7 @@ public class DockerMachine implements DockerConfiguration {
             // 2019-12-17: newer docker-compose adjusts its output based on the number of columns available
             // in the terminal. This interferes with parsing of the output of docker-compose, so "COLUMNS" is
             // set to an artificially large value.
-            combinedEnvironment.put("COLUMNS", "10000"):
+            combinedEnvironment.put("COLUMNS", "10000");
 
             return new DockerMachine(hostIp, ImmutableMap.copyOf(combinedEnvironment));
         }


### PR DESCRIPTION
To fix issue with docker-compose when system terminal is narrow. Also harmonize code according to RemoteBuilder.build.

## Before this PR
Parsing of docker-compose output fails when system terminal is narrow

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Make parsing of docker-compose output independent of local system terminal column width.
==COMMIT_MSG==

## Possible downsides?
Probably none.
