### PR TITLE
match port range output from docker ps

### DIFF
--- a/changelog/@unreleased/pr-695.v2.yml
+++ b/changelog/@unreleased/pr-695.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Map port range mappings from docker ps output.
+  links:
+  - https://github.com/palantir/docker-compose-rule/pull/695

--- a/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/connection/Ports.java
+++ b/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/connection/Ports.java
@@ -65,14 +65,14 @@ public final class Ports {
 
             ports.add(new DockerPort(ip, externalPort, internalPort));
         }
-        Matcher rangeMmatcher = PORT_RANGE_PATTERN.matcher(psOutput);
-        while (rangeMmatcher.find()) {
-            String matchedIpAddress = matcher.group(IP_ADDRESS);
+        Matcher rangeMatcher = PORT_RANGE_PATTERN.matcher(psOutput);
+        while (rangeMatcher.find()) {
+            String matchedIpAddress = rangeMatcher.group(IP_ADDRESS);
             String ip = matchedIpAddress.equals(NO_IP_ADDRESS) ? dockerMachineIp : matchedIpAddress;
-            int externalPortRangeStart = Integer.parseInt(matcher.group(EXTERNAL_PORT_RANGE_START));
-            int externalPortRangeEnd = Integer.parseInt(matcher.group(EXTERNAL_PORT_RANGE_END));
-            int internalPortRangeStart = Integer.parseInt(matcher.group(INTERNAL_PORT_RANGE_START));
-            int internalPortRangeEnd = Integer.parseInt(matcher.group(INTERNAL_PORT_RANGE_END));
+            int externalPortRangeStart = Integer.parseInt(rangeMatcher.group(EXTERNAL_PORT_RANGE_START));
+            int externalPortRangeEnd = Integer.parseInt(rangeMatcher.group(EXTERNAL_PORT_RANGE_END));
+            int internalPortRangeStart = Integer.parseInt(rangeMatcher.group(INTERNAL_PORT_RANGE_START));
+            int internalPortRangeEnd = Integer.parseInt(rangeMatcher.group(INTERNAL_PORT_RANGE_END));
             int len = externalPortRangeEnd - externalPortRangeStart;
             // Sanity check
             if (len == internalPortRangeEnd - internalPortRangeStart) {

--- a/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/connection/Ports.java
+++ b/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/connection/Ports.java
@@ -28,7 +28,8 @@ import java.util.stream.Stream;
 public final class Ports {
 
     private static final Pattern PORT_PATTERN = Pattern.compile("((\\d+).(\\d+).(\\d+).(\\d+)):(\\d+)->(\\d+)/tcp");
-    private static final Pattern PORT_RANGE_PATTERN = Pattern.compile("((\\d+).(\\d+).(\\d+).(\\d+)):(\\d+)-(\\d+)->(\\d+)-(\\d+)/tcp");
+    private static final Pattern PORT_RANGE_PATTERN =
+            Pattern.compile("((\\d+).(\\d+).(\\d+).(\\d+)):(\\d+)-(\\d+)->(\\d+)-(\\d+)/tcp");
     private static final int IP_ADDRESS = 1;
     private static final int EXTERNAL_PORT = 6;
     private static final int INTERNAL_PORT = 7;

--- a/docker-compose-rule-core/src/test/java/com/palantir/docker/compose/connection/PortsShould.java
+++ b/docker-compose-rule-core/src/test/java/com/palantir/docker/compose/connection/PortsShould.java
@@ -65,6 +65,15 @@ public class PortsShould {
     }
 
     @Test
+    public void result_in_two_ports_when_there_are_two_tcp_ports_in_a_range_mapping() {
+        String psOutput = "0.0.0.0:4432-4433->5432-5433/tcp";
+        Ports ports = Ports.parseFromDockerComposePs(psOutput, LOCALHOST_IP);
+        Ports expected = new Ports(
+                newArrayList(new DockerPort(LOCALHOST_IP, 4432, 5432), new DockerPort(LOCALHOST_IP, 4433, 5433)));
+        assertThat(ports, is(expected));
+    }
+
+    @Test
     public void result_in_no_ports_when_there_is_a_non_mapped_exposed_port() {
         String psOutput = "5432/tcp";
         Ports ports = Ports.parseFromDockerComposePs(psOutput, LOCALHOST_IP);


### PR DESCRIPTION
## Before this PR
Port ranges from docker ps output weren't mapped

## After this PR
==COMMIT_MSG==
Map port range mappings from docker ps output
==COMMIT_MSG==

Fixes https://github.com/palantir/docker-compose-rule/issues/689

## Possible downsides?

