### PR TITLE
Use docker compose v2 by default

### DIFF
--- a/changelog/@unreleased/pr-729.v2.yml
+++ b/changelog/@unreleased/pr-729.v2.yml
@@ -1,5 +1,5 @@
-type: improvement
-improvement:
+type: break
+break:
   description: Enable docker-compose v2 by default
   links:
   - https://github.com/palantir/docker-compose-rule/pull/729

--- a/changelog/@unreleased/pr-729.v2.yml
+++ b/changelog/@unreleased/pr-729.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Enable docker-compose v2 by default
+  links:
+  - https://github.com/palantir/docker-compose-rule/pull/729

--- a/docker-compose-rule-core/src/integrationTest/java/com/palantir/docker/compose/RemoveConflictingContainersIntegrationTest.java
+++ b/docker-compose-rule-core/src/integrationTest/java/com/palantir/docker/compose/RemoveConflictingContainersIntegrationTest.java
@@ -46,7 +46,7 @@ public class RemoveConflictingContainersIntegrationTest {
         try {
             composition.before();
             exception.expect(DockerExecutionException.class);
-            exception.expectMessage("'docker-compose up -d' returned exit code");
+            exception.expectMessage("'docker compose up -d' returned exit code");
             conflictingComposition.before();
         } finally {
             composition.after();

--- a/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/DockerComposeManager.java
+++ b/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/DockerComposeManager.java
@@ -107,7 +107,7 @@ public abstract class DockerComposeManager {
 
     @Value.Default
     public boolean useDockerComposeV2() {
-        return false;
+        return true;
     }
 
     @Value.Default


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Enable docker-compose v2 by default, since it's present in internal and external circle
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

