### PR TITLE
Include lastException as cause when docker-compose up fails

### DIFF
--- a/changelog/@unreleased/pr-732.v2.yml
+++ b/changelog/@unreleased/pr-732.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Include lastException as cause when docker-compose up fails
+  links:
+  - https://github.com/palantir/docker-compose-rule/pull/732

--- a/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/execution/ConflictingContainerRemovingDockerCompose.java
+++ b/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/execution/ConflictingContainerRemovingDockerCompose.java
@@ -46,11 +46,13 @@ public final class ConflictingContainerRemovingDockerCompose extends DelegatingD
 
     @Override
     public void up() throws IOException, InterruptedException {
+        DockerExecutionException lastException = null;
         for (int currRetryAttempt = 0; currRetryAttempt <= retryAttempts; currRetryAttempt++) {
             try {
                 getDockerCompose().up();
                 return;
             } catch (DockerExecutionException e) {
+                lastException = e;
                 Set<String> conflictingContainerNames = getConflictingContainerNames(e.getMessage());
                 if (conflictingContainerNames.isEmpty()) {
                     // failed due to reason other than conflicting containers, so re-throw
@@ -66,7 +68,7 @@ public final class ConflictingContainerRemovingDockerCompose extends DelegatingD
             }
         }
 
-        throw new DockerExecutionException("docker-compose up failed");
+        throw new DockerExecutionException("docker-compose up failed", lastException);
     }
 
     private void removeContainers(Collection<String> containerNames) throws IOException, InterruptedException {

--- a/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/execution/DockerExecutionException.java
+++ b/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/execution/DockerExecutionException.java
@@ -21,4 +21,8 @@ public class DockerExecutionException extends RuntimeException {
     public DockerExecutionException(String message) {
         super(message);
     }
+
+    public DockerExecutionException(String message, Throwable cause) {
+        super(message, cause);
+    }
 }


### PR DESCRIPTION
## Before this PR
If docker-compose up fails due to container name conflicts, that information is hidden in debug logs, which are rarely turned on by default.

## After this PR
==COMMIT_MSG==
Include lastException as cause when docker-compose up fails
==COMMIT_MSG==