### PR TITLE
Remove project name validation

### DIFF
--- a/changelog/@unreleased/pr-741.v2.yml
+++ b/changelog/@unreleased/pr-741.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Project names are no longer validation. Any value can be used for a
+    project name.
+  links:
+  - https://github.com/palantir/docker-compose-rule/pull/741

--- a/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/configuration/ProjectName.java
+++ b/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/configuration/ProjectName.java
@@ -15,15 +15,10 @@
  */
 package com.palantir.docker.compose.configuration;
 
-import static com.google.common.base.Preconditions.checkState;
-
 import com.google.common.collect.ImmutableList;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
-import java.util.function.Predicate;
-import java.util.regex.Pattern;
-import org.immutables.value.Value.Check;
 import org.immutables.value.Value.Immutable;
 import org.immutables.value.Value.Parameter;
 
@@ -34,29 +29,6 @@ public abstract class ProjectName {
 
     @Parameter
     protected abstract Optional<String> projectName();
-
-    @Check
-    protected void validate() {
-        if (!projectName().isPresent()) {
-            return;
-        }
-
-        checkState(
-                projectName().get().trim().length() > 0,
-                "ProjectName must not be blank. If you want to omit the project name, use ProjectName.omit()");
-
-        checkState(
-                validCharacters(projectName().get()),
-                "ProjectName '%s' not allowed, please use lowercase letters and numbers only.",
-                projectName().get());
-    }
-
-    // Only allows strings that docker-compose-cli would not modify
-    // https://github.com/docker/compose/blob/85e2fb63b3309280a602f1f76d77d3a82e53b6c2/compose/cli/command.py#L84
-    protected boolean validCharacters(String projectName) {
-        Predicate<String> illegalCharacters = Pattern.compile("[^a-z0-9]").asPredicate();
-        return !illegalCharacters.test(projectName);
-    }
 
     public String asString() {
         return projectName()

--- a/docker-compose-rule-core/src/test/java/com/palantir/docker/compose/configuration/ProjectNameShould.java
+++ b/docker-compose-rule-core/src/test/java/com/palantir/docker/compose/configuration/ProjectNameShould.java
@@ -74,21 +74,6 @@ public class ProjectNameShould {
     }
 
     @Test
-    public void reject_blanks_in_from_string() {
-        exception.expect(IllegalStateException.class);
-        exception.expectMessage("ProjectName must not be blank.");
-        ProjectName.fromString(" ");
-    }
-
-    @Test
-    public void match_validation_behavior_of_docker_compose_cli() {
-        exception.expect(IllegalStateException.class);
-        exception.expectMessage(
-                "ProjectName 'Crazy#Proj ect!Name' not allowed, please use lowercase letters and numbers only.");
-        ProjectName.fromString("Crazy#Proj ect!Name");
-    }
-
-    @Test
     public void should_return_the_project_name_when_asString_called() {
         String projectName = ProjectName.fromString("projectname").asString();
         assertThat(projectName, is("projectname"));


### PR DESCRIPTION
The project name validation no longer matches the Docker Compose behaivor.

https://github.com/docker/compose/pull/5788

Docker Compose will normalize project names if they do not conform to it's requirements.

This is better for consumers because it means they can use the same project names in tests and when running Docker Compose manually.