### PR TITLE
Use docker compose v2 by default everywhere

### DIFF
--- a/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/execution/DockerComposeExecutable.java
+++ b/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/execution/DockerComposeExecutable.java
@@ -108,7 +108,7 @@ public abstract class DockerComposeExecutable implements Executable {
 
     @Value.Default
     public boolean useDockerComposeV2() {
-        return false;
+        return true;
     }
 
     @Override


### PR DESCRIPTION
Missed this in https://github.com/palantir/docker-compose-rule/pull/729