### PR TITLE
[Draft] Add stderr to process result output

### DIFF
--- a/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/execution/Command.java
+++ b/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/execution/Command.java
@@ -80,10 +80,20 @@ public final class Command {
     }
 
     private String processOutputFrom(Process process) {
-        return asReader(process.getInputStream())
+        String stdout = asReader(process.getInputStream())
                 .lines()
                 .peek(logConsumer)
                 .collect(Collectors.joining(System.lineSeparator()));
+
+        String stderr = asReader(process.getErrorStream())
+                .lines()
+                .peek(logConsumer)
+                .collect(Collectors.joining(System.lineSeparator()));
+
+        return String.format(
+                "STDERR: %s\n\n------\n\nSTDOUT: %s\n",
+                stderr.isEmpty() ? "<empty>" : stderr,
+                stdout.isEmpty() ? "<empty>" : stdout);
     }
 
     private static String waitForResultFrom(Future<String> outputProcessing) {

--- a/docker-compose-rule-core/src/test/java/com/palantir/docker/compose/execution/CommandShould.java
+++ b/docker-compose-rule-core/src/test/java/com/palantir/docker/compose/execution/CommandShould.java
@@ -53,6 +53,7 @@ public class CommandShould {
         dockerComposeCommand = new Command(dockerComposeExecutable, logConsumer);
 
         givenTheUnderlyingProcessHasOutput("");
+        givenTheUnderlyingProcessHasError("");
         givenTheUnderlyingProcessTerminatesWithAnExitCodeOf(0);
     }
 
@@ -72,7 +73,7 @@ public class CommandShould {
         givenTheUnderlyingProcessHasOutput(expectedOutput);
         String commandOutput = dockerComposeCommand.execute(errorHandler, "rm", "-f");
 
-        assertThat(commandOutput).isEqualTo(expectedOutput);
+        assertThat(commandOutput).isEqualTo("STDERR: <empty>\n\n------\n\nSTDOUT: " + expectedOutput + "\n");
     }
 
     @Test
@@ -81,7 +82,29 @@ public class CommandShould {
         givenTheUnderlyingProcessHasOutput(expectedOutput);
         String commandOutput = dockerComposeCommand.execute(errorHandler, "rm", "-f");
 
-        assertThat(commandOutput).isEqualTo(expectedOutput);
+        assertThat(commandOutput).isEqualTo("STDERR: <empty>\n\n------\n\nSTDOUT: " + expectedOutput + "\n");
+    }
+
+    @Test
+    public void return_output_when_only_stderr_is_present() throws IOException, InterruptedException {
+        String expectedStderr = "error output";
+        givenTheUnderlyingProcessHasError(expectedStderr);
+        String commandOutput = dockerComposeCommand.execute(errorHandler, "rm", "-f");
+
+        assertThat(commandOutput)
+                .isEqualTo("STDERR: " + expectedStderr + "\n\n------\n\nSTDOUT: <empty>\n");
+    }
+
+    @Test
+    public void return_output_containing_both_stderr_and_stdout() throws IOException, InterruptedException {
+        String expectedStdout = "standard output";
+        String expectedStderr = "error output";
+        givenTheUnderlyingProcessHasOutput(expectedStdout);
+        givenTheUnderlyingProcessHasError(expectedStderr);
+        String commandOutput = dockerComposeCommand.execute(errorHandler, "rm", "-f");
+
+        assertThat(commandOutput)
+                .isEqualTo("STDERR: " + expectedStderr + "\n\n------\n\nSTDOUT: " + expectedStdout + "\n");
     }
 
     @Test
@@ -92,6 +115,16 @@ public class CommandShould {
         dockerComposeCommand.execute(errorHandler, "rm", "-f");
 
         assertThat(consumedLogLines).containsExactly("line 1", "line 2");
+    }
+
+    @Test
+    public void give_both_stdout_and_stderr_to_the_specified_consumer() throws IOException, InterruptedException {
+        givenTheUnderlyingProcessHasOutput("stdout line");
+        givenTheUnderlyingProcessHasError("stderr line");
+
+        dockerComposeCommand.execute(errorHandler, "rm", "-f");
+
+        assertThat(consumedLogLines).containsExactly("stdout line", "stderr line");
     }
 
     // flaky test: https://circleci.com/gh/palantir/docker-compose-rule/378, 370, 367, 366
@@ -108,6 +141,10 @@ public class CommandShould {
 
     private void givenTheUnderlyingProcessHasOutput(String output) {
         when(executedProcess.getInputStream()).thenReturn(toInputStream(output));
+    }
+
+    private void givenTheUnderlyingProcessHasError(String error) {
+        when(executedProcess.getErrorStream()).thenReturn(toInputStream(error));
     }
 
     private void givenTheUnderlyingProcessTerminatesWithAnExitCodeOf(int exitCode) {


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
We don't have access to the stderr. When the process failed internally, the stdout made it seem like the error was related to something else (stdout!), which was misleading.
 
## After this PR
Output returns stderr
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
==COMMIT_MSG==

## Possible downsides?
It's a draft to discuss the format of the output:
1. Changing it in this way now breaks anyone relying exactly on only getting the stdout, in both the output and the errorHandler
2. I've marked empty as <empty> so it doesn't appear like there was an stderr that just got cutoff, but could equally just omit it entirely if no stderr. Chose this way because then it's explicit there's no stderr, rather than unsure if it just got missed e.t.c or a wrong plugin version. 
3. Little bit more verbose now than before.
4. Includes it on a zero status code, though it's valid for programs to output to stderr on zero and it can be potentially useful (or alternatively framed, misleading to hide it)

I'll update the remainder of the tests once agreed on the format!
