### PR TITLE
Filter out docker log messages when listing services

### DIFF
--- a/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/execution/DefaultDockerCompose.java
+++ b/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/execution/DefaultDockerCompose.java
@@ -31,6 +31,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.Validate;
 import org.joda.time.Duration;
@@ -204,7 +205,9 @@ public final class DefaultDockerCompose implements DockerCompose {
     @Override
     public List<String> services() throws IOException, InterruptedException {
         String servicesOutput = command.execute(Command.throwingOnError(), "config", "--services");
-        return Arrays.stream(servicesOutput.split("(\r|\n)+")).filter(service -> !service.contains("level=")).toList();
+        return Arrays.stream(servicesOutput.split("(\r|\n)+"))
+                .filter(service -> !service.contains("level="))
+                .collect(Collectors.toList());
     }
 
     @Override

--- a/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/execution/DefaultDockerCompose.java
+++ b/docker-compose-rule-core/src/main/java/com/palantir/docker/compose/execution/DefaultDockerCompose.java
@@ -204,7 +204,7 @@ public final class DefaultDockerCompose implements DockerCompose {
     @Override
     public List<String> services() throws IOException, InterruptedException {
         String servicesOutput = command.execute(Command.throwingOnError(), "config", "--services");
-        return Arrays.asList(servicesOutput.split("(\r|\n)+"));
+        return Arrays.stream(servicesOutput.split("(\r|\n)+")).filter(service -> !service.contains("level=")).toList();
     }
 
     @Override


### PR DESCRIPTION
## Before this PR
Docker includes a warning about the version field in docker-compose files being deprecated, which gets interpreted as a container and causes the rule to break when it tries to use it as a container. Those log lines look like
```
time="2026-02-13T12:39:07Z" level=warning msg="my-docker-compose-file.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion"
```
 
## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Filter out docker log messages when listing services
==COMMIT_MSG==

## Possible downsides?
Maybe a bit hacky
